### PR TITLE
test(web): browser smoke test for the deck.gl layers (review H1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -211,8 +211,10 @@ jobs:
           cache: true
 
       - name: Install Playwright + Chromium
+        # Pin a bounded range so the smoke test is reproducible — an unpinned install pulls whatever ships that
+        # day into the locked `web` env, outside pixi's lock (review L1).
         run: |
-          pixi run -e web pip install playwright
+          pixi run -e web pip install "playwright>=1.44,<2"
           pixi run -e web playwright install --with-deps chromium
 
       - name: Run the deck.gl browser smoke test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,3 +191,30 @@ jobs:
       - name: Check the web notebooks render
         run: |
           pixi run -e web notebooks-web
+
+  # Browser smoke test for the deck.gl layers (review H1): load a saved WebMap with a deck.gl layer in a
+  # headless Chromium and assert deck.gl renders a canvas with no uncaught JS error / spec rejection.
+  # Playwright + Chromium are NOT in the [web] extra, so they are installed ad-hoc here (the default
+  # tests-web job skips this test).
+  deck-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: serapeum-org/github-actions/actions/python-setup/pixi@0894988f30f270ee8e0d9369f1f62a0deb8d5233 # pixi/v1.1.1
+        with:
+          environments: web
+          activate-environment: web
+          cache: true
+
+      - name: Install Playwright + Chromium
+        run: |
+          pixi run -e web pip install playwright
+          pixi run -e web playwright install --with-deps chromium
+
+      - name: Run the deck.gl browser smoke test
+        run: |
+          pixi run -e web pytest tests/test_web_deck_smoke.py -v

--- a/src/digitalearth/web/bigdata.py
+++ b/src/digitalearth/web/bigdata.py
@@ -196,9 +196,6 @@ class BigDataMixin:
     ) -> "BigDataMixin":
         """Render points as a GPU deck.gl ``GeoJsonLayer`` (recipe W3).
 
-        **Experimental:** the deck.gl layer spec is built and serialised, but its in-browser rendering is not
-        verified by the headless test suite (review H1).
-
         Args:
             features: A pyramids point ``FeatureCollection`` / GeoDataFrame.
             fill_color: RGBA fill colour (0-255 per channel).
@@ -232,9 +229,6 @@ class BigDataMixin:
         line_color: Sequence[int] = (255, 255, 255, 255),
     ) -> "BigDataMixin":
         """Render polygons as a GPU deck.gl ``GeoJsonLayer`` (recipe W3).
-
-        **Experimental:** the deck.gl layer spec is built and serialised, but its in-browser rendering is not
-        verified by the headless test suite (review H1).
 
         Args:
             features: A pyramids polygon ``FeatureCollection`` / GeoDataFrame.

--- a/src/digitalearth/web/threed.py
+++ b/src/digitalearth/web/threed.py
@@ -191,6 +191,10 @@ class ThreeDMixin:
     def tiles_3d(self, url: str, *, opacity: float = 1.0) -> "ThreeDMixin":
         """Render an OGC 3D Tiles / Cesium tileset as a deck.gl ``Tile3DLayer`` (recipe W5).
 
+        **Not browser-verified:** the layer spec is built and serialised, but its in-browser render is not
+        covered by the headless smoke test because it streams a **remote** ``tileset.json`` (the hermetic CI
+        job does not fetch network assets).
+
         Args:
             url: URL of the tileset's ``tileset.json``.
             opacity: Layer opacity in ``[0, 1]``.
@@ -216,6 +220,10 @@ class ThreeDMixin:
         size: float = 1.0,
     ) -> "ThreeDMixin":
         """Place a glTF/GLB 3-D model at ``(lng, lat)`` as a deck.gl ``ScenegraphLayer`` (recipe W5).
+
+        **Not browser-verified:** the layer spec is built and serialised, but its in-browser render is not
+        covered by the headless smoke test because it fetches a **remote** ``.gltf`` / ``.glb`` asset (the
+        hermetic CI job does not fetch network assets).
 
         Args:
             url: URL of the ``.gltf`` / ``.glb`` model.

--- a/src/digitalearth/web/threed.py
+++ b/src/digitalearth/web/threed.py
@@ -164,9 +164,6 @@ class ThreeDMixin:
     ) -> "ThreeDMixin":
         """Render a 3-D point cloud as a deck.gl ``PointCloudLayer`` (recipe W5).
 
-        **Experimental:** the deck.gl layer spec is built and serialised, but its in-browser rendering is not
-        verified by the headless test suite (review H1).
-
         Args:
             points: A point ``FeatureCollection`` / GeoDataFrame (reprojected to lon/lat) or an
                 ``(N, 2|3)`` coordinate array.
@@ -194,9 +191,6 @@ class ThreeDMixin:
     def tiles_3d(self, url: str, *, opacity: float = 1.0) -> "ThreeDMixin":
         """Render an OGC 3D Tiles / Cesium tileset as a deck.gl ``Tile3DLayer`` (recipe W5).
 
-        **Experimental:** the deck.gl layer spec is built and serialised, but its in-browser rendering is not
-        verified by the headless test suite (review H1).
-
         Args:
             url: URL of the tileset's ``tileset.json``.
             opacity: Layer opacity in ``[0, 1]``.
@@ -222,9 +216,6 @@ class ThreeDMixin:
         size: float = 1.0,
     ) -> "ThreeDMixin":
         """Place a glTF/GLB 3-D model at ``(lng, lat)`` as a deck.gl ``ScenegraphLayer`` (recipe W5).
-
-        **Experimental:** the deck.gl layer spec is built and serialised, but its in-browser rendering is not
-        verified by the headless test suite (review H1).
 
         Args:
             url: URL of the ``.gltf`` / ``.glb`` model.

--- a/tests/test_web_deck_smoke.py
+++ b/tests/test_web_deck_smoke.py
@@ -1,0 +1,102 @@
+"""Browser smoke test for the deck.gl layers (review H1).
+
+The deck.gl builders (`deck_scatter` / `deck_polygons` / `point_cloud` / `tiles_3d` / `gltf`) are otherwise
+verified only at the spec level — the rest of the web suite asserts the layer dict is built, not that deck.gl
+accepts and renders it. This test saves a ``WebMap`` with a deck.gl layer to standalone HTML (which embeds the
+deck.gl JSON), loads it in a headless Chromium via Playwright, and asserts deck.gl initialises a canvas with
+**no uncaught JS error and no deck.gl spec-rejection** — i.e. the ``@@type`` / ``@@=`` accessor JSON is valid.
+
+Gated: Playwright and a Chromium browser are **not** part of the ``[web]`` extra, so this skips unless both
+are installed. The CI ``deck-smoke`` job installs them and runs it; the default ``test-web`` suite skips it.
+"""
+
+import pytest
+
+pytest.importorskip("maplibre")
+pytest.importorskip("playwright")
+
+
+def _render_and_collect(uri: str):
+    """Load ``uri`` in headless Chromium, return ``(page_errors, console_errors, canvas_count)``.
+
+    Skips the test (rather than failing) when no Chromium binary is available, so a machine with the
+    Playwright Python package but no installed browser does not produce a false failure.
+    """
+    from playwright.sync_api import sync_playwright
+
+    page_errors: list = []
+    console_errors: list = []
+    with sync_playwright() as play:
+        try:
+            browser = play.chromium.launch()
+        except Exception as exc:  # browser not installed / cannot launch -> skip, don't fail
+            pytest.skip(f"Chromium not available for Playwright: {exc}")
+        page = browser.new_page(viewport={"width": 900, "height": 700})
+        page.on("pageerror", lambda err: page_errors.append(str(err)))
+        page.on("console", lambda msg: console_errors.append(msg.text) if msg.type == "error" else None)
+        page.goto(uri, wait_until="load")
+        try:
+            page.wait_for_selector("canvas", timeout=20000)  # the MapLibre / deck.gl WebGL canvas
+        except Exception:
+            pass
+        page.wait_for_timeout(3000)  # let deck.gl finish its first render after the libs load
+        canvas_count = page.locator("canvas").count()
+        browser.close()
+    return page_errors, console_errors, canvas_count
+
+
+@pytest.fixture()
+def points_gdf():
+    """A few points in lon/lat for a deck.gl scatter layer."""
+    gpd = pytest.importorskip("geopandas")
+    from shapely.geometry import Point
+
+    return gpd.GeoDataFrame(
+        {"v": [1.0, 2.0, 3.0, 4.0]},
+        geometry=[Point(i * 0.1, i * 0.1) for i in range(4)],
+        crs=4326,
+    )
+
+
+@pytest.fixture()
+def polygons_gdf():
+    """A couple of polygons in lon/lat for a deck.gl polygon layer."""
+    gpd = pytest.importorskip("geopandas")
+    from shapely.geometry import Polygon
+
+    return gpd.GeoDataFrame(
+        {"v": [1.0, 2.0]},
+        geometry=[
+            Polygon([(0, 0), (0.1, 0), (0.1, 0.1)]),
+            Polygon([(0.2, 0.2), (0.3, 0.2), (0.3, 0.3)]),
+        ],
+        crs=4326,
+    )
+
+
+def _assert_clean_deck_render(page_errors, console_errors, canvas_count):
+    """Shared assertions: no JS exception, no deck.gl spec rejection, a canvas was rendered."""
+    assert not page_errors, f"uncaught JS error rendering the deck.gl layer: {page_errors}"
+    deck_errors = [
+        e for e in console_errors if any(k in e.lower() for k in ("deck", "layer", "geojson", "@@"))
+    ]
+    assert not deck_errors, f"deck.gl rejected the layer spec: {deck_errors}"
+    assert canvas_count >= 1, "no canvas rendered — deck.gl / MapLibre did not initialise"
+
+
+class TestDeckRendersInBrowser:
+    """The deck.gl JSON specs render in a real browser (promotes them out of 'experimental')."""
+
+    def test_deck_scatter_renders(self, tmp_path, points_gdf):
+        from digitalearth.web import WebMap
+
+        out = tmp_path / "deck_scatter.html"
+        WebMap().deck_scatter(points_gdf).save(str(out))
+        _assert_clean_deck_render(*_render_and_collect(out.as_uri()))
+
+    def test_deck_polygons_renders(self, tmp_path, polygons_gdf):
+        from digitalearth.web import WebMap
+
+        out = tmp_path / "deck_polygons.html"
+        WebMap().deck_polygons(polygons_gdf).save(str(out))
+        _assert_clean_deck_render(*_render_and_collect(out.as_uri()))

--- a/tests/test_web_deck_smoke.py
+++ b/tests/test_web_deck_smoke.py
@@ -1,10 +1,18 @@
 """Browser smoke test for the deck.gl layers (review H1).
 
-The deck.gl builders (`deck_scatter` / `deck_polygons` / `point_cloud` / `tiles_3d` / `gltf`) are otherwise
-verified only at the spec level — the rest of the web suite asserts the layer dict is built, not that deck.gl
-accepts and renders it. This test saves a ``WebMap`` with a deck.gl layer to standalone HTML (which embeds the
-deck.gl JSON), loads it in a headless Chromium via Playwright, and asserts deck.gl initialises a canvas with
-**no uncaught JS error and no deck.gl spec-rejection** — i.e. the ``@@type`` / ``@@=`` accessor JSON is valid.
+The deck.gl builders are otherwise verified only at the spec level — the rest of the web suite asserts the layer
+dict is built, not that deck.gl accepts and renders it. This test saves a ``WebMap`` with a deck.gl layer to
+standalone HTML (which embeds the deck.gl JSON), loads it in a headless Chromium via Playwright, and asserts
+deck.gl initialises with **no uncaught JS error and no deck.gl spec-rejection** — i.e. the ``@@type`` / ``@@=``
+accessor JSON is valid.
+
+Coverage: the local-data builders — ``deck_scatter`` / ``deck_polygons`` / ``point_cloud`` — are browser-verified
+here. ``tiles_3d`` / ``gltf`` are **not** covered: they stream remote assets (a ``tileset.json`` / a ``.glb``),
+which this hermetic job must not fetch; their docstrings keep a "not browser-verified" caveat.
+
+Note: MapLibre owns the base ``<canvas>``, so the canvas count is a liveness check, not deck-specific proof — each
+test therefore also asserts the saved HTML actually embedded the deck.gl layer spec (the ``@@type`` accessor), so a
+regression that drops the deck JSON fails here.
 
 Gated: Playwright and a Chromium browser are **not** part of the ``[web]`` extra, so this skips unless both
 are installed. The CI ``deck-smoke`` job installs them and runs it; the default ``test-web`` suite skips it.
@@ -22,6 +30,7 @@ def _render_and_collect(uri: str):
     Skips the test (rather than failing) when no Chromium binary is available, so a machine with the
     Playwright Python package but no installed browser does not produce a false failure.
     """
+    from playwright.sync_api import TimeoutError as PWTimeout
     from playwright.sync_api import sync_playwright
 
     page_errors: list = []
@@ -37,7 +46,7 @@ def _render_and_collect(uri: str):
         page.goto(uri, wait_until="load")
         try:
             page.wait_for_selector("canvas", timeout=20000)  # the MapLibre / deck.gl WebGL canvas
-        except Exception:
+        except PWTimeout:  # no canvas in time -> the canvas_count assertion below reports it
             pass
         page.wait_for_timeout(3000)  # let deck.gl finish its first render after the libs load
         canvas_count = page.locator("canvas").count()
@@ -74,12 +83,25 @@ def polygons_gdf():
     )
 
 
+#: deck-specific markers a console *error* would carry if deck.gl rejected the spec. Deliberately narrow — the
+#: bare words ``layer`` / ``geojson`` match unrelated MapLibre messages, so only deck-flavoured tokens are used.
+_DECK_ERROR_MARKERS = ("deck", "@@", "geojsonlayer", "pointcloudlayer", "scenegraphlayer", "tile3dlayer")
+
+
+def _assert_html_has_deck_spec(html_path):
+    """Fail if the saved HTML never embedded a deck.gl layer spec (guards a regression in ``save()``)."""
+    html = html_path.read_text(encoding="utf-8")
+    assert "@@type" in html, f"saved HTML embeds no deck.gl layer spec (no '@@type' accessor): {html_path}"
+
+
 def _assert_clean_deck_render(page_errors, console_errors, canvas_count):
-    """Shared assertions: no JS exception, no deck.gl spec rejection, a canvas was rendered."""
+    """Shared assertions: no JS exception, no deck.gl spec rejection, a (MapLibre/deck) canvas was rendered.
+
+    Note: MapLibre owns the base canvas, so ``canvas_count`` is a liveness check; deck-specific proof comes from
+    the no-rejection gate plus the caller's :func:`_assert_html_has_deck_spec` check on the embedded JSON.
+    """
     assert not page_errors, f"uncaught JS error rendering the deck.gl layer: {page_errors}"
-    deck_errors = [
-        e for e in console_errors if any(k in e.lower() for k in ("deck", "layer", "geojson", "@@"))
-    ]
+    deck_errors = [e for e in console_errors if any(k in e.lower() for k in _DECK_ERROR_MARKERS)]
     assert not deck_errors, f"deck.gl rejected the layer spec: {deck_errors}"
     assert canvas_count >= 1, "no canvas rendered — deck.gl / MapLibre did not initialise"
 
@@ -92,6 +114,7 @@ class TestDeckRendersInBrowser:
 
         out = tmp_path / "deck_scatter.html"
         WebMap().deck_scatter(points_gdf).save(str(out))
+        _assert_html_has_deck_spec(out)
         _assert_clean_deck_render(*_render_and_collect(out.as_uri()))
 
     def test_deck_polygons_renders(self, tmp_path, polygons_gdf):
@@ -99,4 +122,14 @@ class TestDeckRendersInBrowser:
 
         out = tmp_path / "deck_polygons.html"
         WebMap().deck_polygons(polygons_gdf).save(str(out))
+        _assert_html_has_deck_spec(out)
+        _assert_clean_deck_render(*_render_and_collect(out.as_uri()))
+
+    def test_point_cloud_renders(self, tmp_path, points_gdf):
+        """``point_cloud`` takes local coords (no network), so it is browser-verifiable like scatter/polygons."""
+        from digitalearth.web import WebMap
+
+        out = tmp_path / "deck_point_cloud.html"
+        WebMap().point_cloud(points_gdf).save(str(out))
+        _assert_html_has_deck_spec(out)
         _assert_clean_deck_render(*_render_and_collect(out.as_uri()))


### PR DESCRIPTION
# Description

Follow-up to the web tier (merged in #96) — closes review finding **H1**. The deck.gl builders were verified only
at the **spec level** (the suite asserted the layer dict was built, not that deck.gl accepts and renders it), so
they carried an "Experimental: in-browser rendering is not verified" docstring caveat. This adds a Playwright +
headless-Chromium smoke test that loads a saved `WebMap` (the standalone HTML embeds the deck.gl JSON) and asserts
deck.gl initialises with **no uncaught JS error and no spec rejection** (the `@@type` / `@@=` accessor JSON is
valid) — letting the browser-verifiable builders drop their "experimental" label.

- **`tests/test_web_deck_smoke.py`** (new, gated — skips unless Playwright **and** Chromium are installed, so the
  default `test-web` suite skips it): browser-renders `deck_scatter`, `deck_polygons` **and** `point_cloud`. Each
  test also asserts the saved HTML embedded the deck spec (`@@type`), since MapLibre owns the base canvas so a
  canvas count alone does not prove the deck overlay drew.
- **`src/digitalearth/web/bigdata.py`, `threed.py`**: drop the "experimental" caveat from `deck_scatter`,
  `deck_polygons`, `point_cloud` (now browser-verified). `tiles_3d` / `gltf` keep a reworded "not browser-verified
  (remote assets)" caveat — they stream a remote `tileset.json` / `.glb` the hermetic CI job must not fetch.
- **`.github/workflows/tests.yml`**: a `deck-smoke` job (web env) that installs a pinned Playwright (`>=1.44,<2`) +
  Chromium and runs the test.

Reviewed twice with the review workflow (two rounds); findings M1/M2/L1/L2/N1 fixed in `5395077`, second pass clean.

- Closes #109

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue) <!-- closes review H1: test/docstring correctness -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update <!-- docstring caveats updated -->

> Test + CI + docstrings only — no production code path changes.

# How Has This Been Tested?

- New `deck-smoke` CI job runs the smoke test for real (pinned Playwright + Chromium on Ubuntu) → **green** on this
  PR's head, browser-rendering `deck_scatter` / `deck_polygons` / `point_cloud`.
- `pixi run -e web test-web` → **99 passed, 1 skipped** (the smoke module skips cleanly where Playwright is absent,
  so it does not affect the default `test-web` job).
- `py_compile` clean; `tests.yml` valid YAML.

- [x] `deck-smoke` CI job (browser render of the three local-data builders)
- [x] `pixi run -e web test-web` (99 passed, 1 skipped)

Test configuration: gated browser test; runs in the `web` pixi env with pinned Playwright + Chromium on Ubuntu CI.

# Checklist:

- [ ] updated version number in setup.py/pyproject.toml <!-- N/A — bumped by commitizen in CI -->
- [ ] updated environment.yml and the lock file <!-- N/A — Playwright installed (pinned) in the CI job, test-only -->
- [ ] added changes to History.rst <!-- N/A — changelog generated by commitizen in CI -->
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
