### PR TITLE
feat: Area E charts & symbology + web map controls (DC.1/3/4/5/6/8, ED.10/13)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -61,7 +59,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -106,7 +104,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -205,7 +203,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl
@@ -299,7 +297,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl
@@ -313,8 +311,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -369,7 +365,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -517,7 +513,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -560,7 +556,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -762,7 +758,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -804,7 +800,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -997,7 +993,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -1041,7 +1037,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -1055,8 +1051,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1111,7 +1105,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -1249,7 +1243,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -1472,7 +1466,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl
@@ -1686,7 +1680,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl
@@ -1730,8 +1724,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1786,7 +1778,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -1952,7 +1944,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/09/e27388e25d5ba562b19b3893140469355150cfa9d49a4184e5033d7464c9/pyshp-3.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
@@ -2000,7 +1992,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -2222,7 +2214,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/09/e27388e25d5ba562b19b3893140469355150cfa9d49a4184e5033d7464c9/pyshp-3.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
@@ -2269,7 +2261,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -2482,7 +2474,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/09/e27388e25d5ba562b19b3893140469355150cfa9d49a4184e5033d7464c9/pyshp-3.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
@@ -2531,7 +2523,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -2547,8 +2539,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -2603,7 +2593,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -2716,7 +2706,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -2909,7 +2899,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl
@@ -3094,7 +3084,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl
@@ -3133,8 +3123,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -3188,7 +3176,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
@@ -3340,7 +3328,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ad/ab/9bdb4a6216b712a1f9aab1c0fcbee5d3726f34a366f29c3e8c08a78d6b70/pyproj-3.7.2-cp311-cp311-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b5/28/823297f2c658da0153e9ff4cc985d65d86e3fda7671af3614f288c8341a5/pyramids_gis-0.34.0-cp311-cp311-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/80/63/8e6e6aafc4ae6a40d776b38b3ef39688c708ffd4167c67ab2d0ba46244c8/pyramids_gis-0.35.0-cp311-cp311-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -3383,7 +3371,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -3588,7 +3576,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/bd/f205552cd1713b08f93b09e39a3ec99edef0b3ebbbca67b486fdf1abe2de/pyproj-3.7.2-cp311-cp311-macosx_13_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/df/23d6616347a56b28bc288d9cc9087bef78846316ea1a18c474a0ddfc0111/pyramids_gis-0.34.0-cp311-cp311-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/59/5777d5f3d06950f9bc41e5ebb40b7c6cdb2c0d3a7f581b001d485efc6df0/pyramids_gis-0.35.0-cp311-cp311-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -3630,7 +3618,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -3826,7 +3814,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/e0/b95584605cec9ed50b7ebaf7975d1c4ddeec5a86b7a20554ed8b60042bd7/pyproj-3.7.2-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/89/16e5ceda55d4a59728abbd4cc63759fc4256c28562d8c7035b547edc27da/pyramids_gis-0.34.0-cp311-cp311-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/04/8dba88566064c2f24a15124be7a733517f374d8f5e3d23304d53f4b0f6e9/pyramids_gis-0.35.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -3870,7 +3858,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -3885,8 +3873,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -3940,7 +3926,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
@@ -4089,7 +4075,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/be/212882c450bba74fc8d7d35cbd57e4af84792f0a56194819d98106b075af/pyproj-3.7.2-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e5/4e/8279d0d5f4bafec03fe76147f2d6d066faa6bbfa62a6d68bef2dd11cb9ec/pyramids_gis-0.34.0-cp312-cp312-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/83/18/96c1b4f82066d6e61964cc3e69b0e28514a9115b948c513cea32f30fd36e/pyramids_gis-0.35.0-cp312-cp312-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -4132,7 +4118,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -4333,7 +4319,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/ab/9893ea9fb066be70ed9074ae543914a618c131ed8dff2da1e08b3a4df4db/pyproj-3.7.2-cp312-cp312-macosx_13_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b7/06/44368d23ffa925a9bfd57a5d287911a1396812451f6c00fa10b9e72b2cff/pyramids_gis-0.34.0-cp312-cp312-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/7e/6686eaaef14c8a80131ce2f35491e2753b8cb353854db6ba0065bca65f7e/pyramids_gis-0.35.0-cp312-cp312-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -4375,7 +4361,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -4567,7 +4553,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/a6/6fe724b72b70f2b00152d77282e14964d60ab092ec225e67c196c9b463e5/pyproj-3.7.2-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/6e/2fcbb7a0099c6b2d2dfc2dabfc19638b827a0dd82d6c620adc3cbb31bb0e/pyramids_gis-0.34.0-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/27/4dd1877078ab5e9f63ff13f5824bc5659e38710520340938102236e4414e/pyramids_gis-0.35.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -4611,7 +4597,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -4625,8 +4611,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -4681,7 +4665,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -4829,7 +4813,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -4872,7 +4856,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -5074,7 +5058,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -5116,7 +5100,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -5309,7 +5293,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -5353,7 +5337,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -5367,8 +5351,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -5423,7 +5405,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -5591,7 +5573,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/09/e27388e25d5ba562b19b3893140469355150cfa9d49a4184e5033d7464c9/pyshp-3.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
@@ -5644,7 +5626,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/75/4a1fe360256b99779d534b2387d0efa70952167d53d716f60ff39d62994d/vtk-9.6.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
@@ -5869,7 +5851,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/09/e27388e25d5ba562b19b3893140469355150cfa9d49a4184e5033d7464c9/pyshp-3.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
@@ -5921,7 +5903,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/b8/2eb42db93ac200180ca1a6ffe6f95d010181528e9490464621c31628e35f/vtk-9.6.2-cp313-cp313-macosx_10_10_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
@@ -6137,7 +6119,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/09/e27388e25d5ba562b19b3893140469355150cfa9d49a4184e5033d7464c9/pyshp-3.0.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
@@ -6191,7 +6173,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/da/5b/e03640322971339899f982691396038d793ecfde8adbc208a97d501d6b8e/vtk-9.6.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
@@ -6208,8 +6190,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -6264,7 +6244,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
@@ -6425,7 +6405,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -6469,7 +6449,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -6684,7 +6664,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -6727,7 +6707,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -6933,7 +6913,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl
@@ -6978,7 +6958,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -8287,12 +8267,12 @@ packages:
 - pypi: ./
   name: digitalearth
   version: 0.7.0
-  sha256: 2332e483b563beb195b7698288c34f6b291ec5e5fc5e1a58d5ed17d5b3359d6c
+  sha256: 47c24f1d03365ad50145032b324bf2e1f993cae2be3479d2e48aa70eef374206
   requires_dist:
   - numpy>=2.0.0
   - geopandas>=1.1.3
   - cleopatra>=0.18.0
-  - pyramids-gis>=0.32.0
+  - pyramids-gis>=0.35.0
   - loguru>=0.7.3
   - pyyaml>=6.0
   - pyvista>=0.48 ; extra == '3d'
@@ -8310,6 +8290,7 @@ packages:
   - maplibre>=0.3 ; extra == 'web'
   - lonboard>=0.10 ; extra == 'web'
   requires_python: '>=3.11,<4'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
   name: distlib
   version: 0.4.3
@@ -8899,7 +8880,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/gdal?source=compressed-mapping
+  - pkg:pypi/gdal?source=hash-mapping
   size: 2514658
   timestamp: 1781521928633
 - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py311h8e56c0d_1.conda
@@ -12213,17 +12194,16 @@ packages:
   purls: []
   size: 993166
   timestamp: 1762022118895
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
-  sha256: 3f0edf1280e2f6684a986f821eaa3e123d2694a00b31b96ca0d4a4c12c129231
-  md5: 7d0a66598195ef00b6efc55aefc7453b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 40163
-  timestamp: 1779118517630
+  size: 40017
+  timestamp: 1781625522462
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
   sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
   md5: aea31d2e5b1091feca96fcfe945c3cf9
@@ -16052,10 +16032,10 @@ packages:
   version: 1.2.0
   sha256: 9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/1c/46/4fdf3222320258cb92e8b2dbfa4ddda38491483a71d094038f21088b976d/pyramids_gis-0.34.0-cp313-cp313-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/14/04/8dba88566064c2f24a15124be7a733517f374d8f5e3d23304d53f4b0f6e9/pyramids_gis-0.35.0-cp311-cp311-win_amd64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: 17634634f8793dd4d5196b97124cb571f5fdf837370f6da2588d6c2dea3ef876
+  version: 0.35.0
+  sha256: 38b62102d3dbde3c43c08a99a9ab46d7d01b0eb4f927d0c9abc3ab01051cdba1
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16064,7 +16044,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -16081,10 +16061,10 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-- pypi: https://files.pythonhosted.org/packages/ad/6e/2fcbb7a0099c6b2d2dfc2dabfc19638b827a0dd82d6c620adc3cbb31bb0e/pyramids_gis-0.34.0-cp312-cp312-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/14/27/4dd1877078ab5e9f63ff13f5824bc5659e38710520340938102236e4414e/pyramids_gis-0.35.0-cp312-cp312-win_amd64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: 94f6eefba54ef7cd9c147e02b2ee1c805e421729610b1787d91437463efa7b0f
+  version: 0.35.0
+  sha256: bb2bfb6469d8284e3bed95dcd89c14a2a787203cf53a5bec77ab3241d4f02857
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16093,7 +16073,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -16110,10 +16090,10 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-- pypi: https://files.pythonhosted.org/packages/ae/89/16e5ceda55d4a59728abbd4cc63759fc4256c28562d8c7035b547edc27da/pyramids_gis-0.34.0-cp311-cp311-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/1f/59/5777d5f3d06950f9bc41e5ebb40b7c6cdb2c0d3a7f581b001d485efc6df0/pyramids_gis-0.35.0-cp311-cp311-macosx_11_0_x86_64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: 0600bba956d6b76c408fee034b27efd0d17685ec79c35b40afce999da4e14175
+  version: 0.35.0
+  sha256: 4ce8633b4e92207f2a86c34cedcda99591250e7337b5bdd7bb9e301649be2c56
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16122,7 +16102,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -16139,10 +16119,10 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-- pypi: https://files.pythonhosted.org/packages/b3/df/23d6616347a56b28bc288d9cc9087bef78846316ea1a18c474a0ddfc0111/pyramids_gis-0.34.0-cp311-cp311-macosx_11_0_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/53/f9/56ada3ebfbf18cbd6fe4da0d7d2d4bde9a25c863399ef218f8a78ab4f756/pyramids_gis-0.35.0-cp313-cp313-manylinux_2_39_x86_64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: e70998a477d0d7f0c3ac58d046fe3ed1064a718261efd606faf190cbe392781b
+  version: 0.35.0
+  sha256: 959565b861e0661faf0cebf5dd19dab5e4da49296166a235725ae2c3ed95d15f
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16151,7 +16131,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -16168,10 +16148,10 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-- pypi: https://files.pythonhosted.org/packages/b5/28/823297f2c658da0153e9ff4cc985d65d86e3fda7671af3614f288c8341a5/pyramids_gis-0.34.0-cp311-cp311-manylinux_2_39_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/6d/7e/6686eaaef14c8a80131ce2f35491e2753b8cb353854db6ba0065bca65f7e/pyramids_gis-0.35.0-cp312-cp312-macosx_11_0_x86_64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: 4326332ee007db36fdc2fe3330901c1f517d7c536bf6a6b1603f5d230a589bb8
+  version: 0.35.0
+  sha256: 9eed5a1edaf568e550b7c696cd610385b9a03a492d7155d67c24df85ce99d07e
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16180,7 +16160,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -16197,10 +16177,10 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-- pypi: https://files.pythonhosted.org/packages/b7/06/44368d23ffa925a9bfd57a5d287911a1396812451f6c00fa10b9e72b2cff/pyramids_gis-0.34.0-cp312-cp312-macosx_11_0_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/80/63/8e6e6aafc4ae6a40d776b38b3ef39688c708ffd4167c67ab2d0ba46244c8/pyramids_gis-0.35.0-cp311-cp311-manylinux_2_39_x86_64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: 395c5c2c3983a94f9438b99946aed40801d8beed2e219cdbddfbb4600a09568f
+  version: 0.35.0
+  sha256: ea3f99f52ddf25162a142ee01342903f0c7d32e7fc595b9a8298d8978ef59841
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16209,7 +16189,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -16226,10 +16206,10 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-- pypi: https://files.pythonhosted.org/packages/df/50/5a8844308d02383d64dedd3b4a00082a8a4a2f734c3f73f7d4a55d7f1b30/pyramids_gis-0.34.0-cp313-cp313-manylinux_2_39_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/83/18/96c1b4f82066d6e61964cc3e69b0e28514a9115b948c513cea32f30fd36e/pyramids_gis-0.35.0-cp312-cp312-manylinux_2_39_x86_64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: 011e70dfb74c2e0cb0a559389b8f2233cbc3c4bf36fa87aa116cdc98f15f0b88
+  version: 0.35.0
+  sha256: c179cb1244c7ca63ba5502d4554177bcb3959c993ccadb556841b901fc49bec0
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16238,7 +16218,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -16255,10 +16235,10 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-- pypi: https://files.pythonhosted.org/packages/e5/4e/8279d0d5f4bafec03fe76147f2d6d066faa6bbfa62a6d68bef2dd11cb9ec/pyramids_gis-0.34.0-cp312-cp312-manylinux_2_39_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/9f/29/520ba71d7229a79029665c8d767bbfe457a059458591b834065159c74379/pyramids_gis-0.35.0-cp313-cp313-win_amd64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: 9f0daea9029cfcbfd7b764d7534df7ca3f15db82c8808cb89e0f39e82bfdc00b
+  version: 0.35.0
+  sha256: 8e49534835c38be94406bf10479c57182679dfc1dd589be1e0097acdfc30e948
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16267,7 +16247,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -16284,10 +16264,10 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-- pypi: https://files.pythonhosted.org/packages/fc/20/ac5ceaa837764624d5bd02d4f6ac1e6e114fba182ce9d9219dd16bda887d/pyramids_gis-0.34.0-cp313-cp313-macosx_11_0_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/aa/f4/cd2f6562f1f730aee1a13a9c1ca180ed7abf17ddce37a3914e06cb5c6928/pyramids_gis-0.35.0-cp313-cp313-macosx_11_0_x86_64.whl
   name: pyramids-gis
-  version: 0.34.0
-  sha256: 1c6b275307e4480a972754fc30fc0f207f72be5ce71c8529b117d3f01ddbddad
+  version: 0.35.0
+  sha256: bd7ee7198ce605669afaa434d1720900c3fc3ba4e503385c3e11f3d7f6b06a7d
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -16296,7 +16276,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -18191,10 +18171,10 @@ packages:
   - mypy ; extra == 'test'
   - pretend ; extra == 'test'
   - pytest ; extra == 'test'
-- pypi: https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
   name: virtualenv
-  version: 21.5.0
-  sha256: 8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e
+  version: 21.5.1
+  sha256: 55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783
   requires_dist:
   - distlib>=0.3.7,<1
   - filelock>=3.24.2,<4 ; python_full_version >= '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "numpy >=2.0.0",
     "geopandas >=1.1.3",
     "cleopatra >=0.18.0",
-    "pyramids-gis >=0.32.0",
+    "pyramids-gis >=0.35.0",
     "loguru >=0.7.3",
     "pyyaml >=6.0",
 ]

--- a/src/digitalearth/__init__.py
+++ b/src/digitalearth/__init__.py
@@ -38,7 +38,15 @@ digitalearth - visualization package
 from digitalearth.api import quickmap, quickplot  # noqa: E402
 from digitalearth.batch import Batch  # noqa: E402
 from digitalearth.browser import gallery  # noqa: E402
-from digitalearth.charts import bar, histogram, line, scatter, statistics  # noqa: E402
+from digitalearth.charts import (  # noqa: E402
+    bar,
+    bar_by,
+    histogram,
+    line,
+    line_by,
+    scatter,
+    statistics,
+)
 from digitalearth.plugins import load_plugins  # noqa: E402
 from digitalearth.scene import Map, Scene, grid, projections, shared_colorbar  # noqa: E402
 from digitalearth.series import (  # noqa: E402
@@ -57,7 +65,7 @@ __all__ = [
     # data view
     "get_source", "Source", "DimensionInfo",
     # charts and statistical series
-    "line", "bar", "histogram", "scatter", "statistics",
+    "line", "bar", "bar_by", "line_by", "histogram", "scatter", "statistics",
     "envelope", "quantile_band", "boxplot", "multiboxplot", "stripes",
     # temporal products
     "TimeSeries", "Climatology",

--- a/src/digitalearth/__init__.py
+++ b/src/digitalearth/__init__.py
@@ -38,7 +38,7 @@ digitalearth - visualization package
 from digitalearth.api import quickmap, quickplot  # noqa: E402
 from digitalearth.batch import Batch  # noqa: E402
 from digitalearth.browser import gallery  # noqa: E402
-from digitalearth.charts import bar, histogram, line, statistics  # noqa: E402
+from digitalearth.charts import bar, histogram, line, scatter, statistics  # noqa: E402
 from digitalearth.plugins import load_plugins  # noqa: E402
 from digitalearth.scene import Map, Scene, grid, projections, shared_colorbar  # noqa: E402
 from digitalearth.series import (  # noqa: E402
@@ -57,7 +57,7 @@ __all__ = [
     # data view
     "get_source", "Source", "DimensionInfo",
     # charts and statistical series
-    "line", "bar", "histogram", "statistics",
+    "line", "bar", "histogram", "scatter", "statistics",
     "envelope", "quantile_band", "boxplot", "multiboxplot", "stripes",
     # temporal products
     "TimeSeries", "Climatology",

--- a/src/digitalearth/__init__.py
+++ b/src/digitalearth/__init__.py
@@ -38,7 +38,7 @@ digitalearth - visualization package
 from digitalearth.api import quickmap, quickplot  # noqa: E402
 from digitalearth.batch import Batch  # noqa: E402
 from digitalearth.browser import gallery  # noqa: E402
-from digitalearth.charts import bar, histogram, line  # noqa: E402
+from digitalearth.charts import bar, histogram, line, statistics  # noqa: E402
 from digitalearth.plugins import load_plugins  # noqa: E402
 from digitalearth.scene import Map, Scene, grid, projections, shared_colorbar  # noqa: E402
 from digitalearth.series import (  # noqa: E402
@@ -57,7 +57,7 @@ __all__ = [
     # data view
     "get_source", "Source", "DimensionInfo",
     # charts and statistical series
-    "line", "bar", "histogram",
+    "line", "bar", "histogram", "statistics",
     "envelope", "quantile_band", "boxplot", "multiboxplot", "stripes",
     # temporal products
     "TimeSeries", "Climatology",

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -34,6 +34,22 @@ def resolve_categorical_cmap(cmap: str) -> str:
 
     Returns:
         ``cmap`` unchanged, unless it is the continuous default — then the qualitative categorical default.
+
+    Examples:
+        - The continuous default is swapped for a qualitative colormap:
+            ```python
+            >>> from digitalearth._symbology import resolve_categorical_cmap
+            >>> resolve_categorical_cmap("viridis")
+            'tab10'
+
+            ```
+        - An explicitly chosen colormap is left untouched:
+            ```python
+            >>> from digitalearth._symbology import resolve_categorical_cmap
+            >>> resolve_categorical_cmap("Set2")
+            'Set2'
+
+            ```
     """
     return _DEFAULT_CATEGORICAL_CMAP if cmap == _CONTINUOUS_DEFAULT_CMAP else cmap
 

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -17,6 +17,26 @@ import numpy as np
 #: Default qualitative colormap for categorical symbology (10 distinct hues; cycled if more categories).
 _DEFAULT_CATEGORICAL_CMAP = "tab10"
 
+#: The continuous-colour default ``choropleth`` carries in its signature (right for graduated/continuous,
+#: a poor fit for categorical). The categorical path swaps it for ``_DEFAULT_CATEGORICAL_CMAP``.
+_CONTINUOUS_DEFAULT_CMAP = "viridis"
+
+
+def resolve_categorical_cmap(cmap: str) -> str:
+    """Pick the colormap for categorical symbology, swapping the continuous default for a qualitative one.
+
+    ``choropleth``'s ``cmap`` defaults to the continuous ``"viridis"`` (right for graduated/continuous
+    colouring). That sequential map reads poorly as discrete categories, so when the caller leaves the default
+    in place it is swapped for :data:`_DEFAULT_CATEGORICAL_CMAP`; an explicit ``cmap`` is always honoured.
+
+    Args:
+        cmap: The colormap name passed to ``choropleth`` (a qualitative map is preferred for categorical).
+
+    Returns:
+        ``cmap`` unchanged, unless it is the continuous default — then the qualitative categorical default.
+    """
+    return _DEFAULT_CATEGORICAL_CMAP if cmap == _CONTINUOUS_DEFAULT_CMAP else cmap
+
 
 def _categories(values: Any) -> List[Any]:
     """Return the distinct, non-null values of ``values`` in a stable order (sorted when sortable).

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -27,7 +27,12 @@ def resolve_categorical_cmap(cmap: str) -> str:
 
     ``choropleth``'s ``cmap`` defaults to the continuous ``"viridis"`` (right for graduated/continuous
     colouring). That sequential map reads poorly as discrete categories, so when the caller leaves the default
-    in place it is swapped for :data:`_DEFAULT_CATEGORICAL_CMAP`; an explicit ``cmap`` is always honoured.
+    in place it is swapped for :data:`_DEFAULT_CATEGORICAL_CMAP`; any other explicit ``cmap`` is honoured.
+
+    Note this cannot distinguish "caller left the default" from "caller explicitly passed ``"viridis"``" — both
+    are swapped to the qualitative default. To force a viridis categorical map, pass a distinct spelling such as
+    ``"viridis_r"`` (or sample viridis yourself); this is deliberate, since viridis rarely reads well as
+    discrete categories.
 
     Args:
         cmap: The colormap name passed to ``choropleth`` (a qualitative map is preferred for categorical).

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -1,0 +1,93 @@
+"""Shared symbology helpers — categorical (distinct-value → colour) mapping for thematic maps (DC.8).
+
+Graduated / continuous classification lives upstream in ``cleopatra.styles.classify`` (numeric breaks); this
+module is the **categorical** counterpart: map each distinct value of a field to a colour from a qualitative
+colormap. It is pure numpy + matplotlib colour work (styling, not GIS), consumed by the tiers' ``choropleth``
+``scheme="categorical"`` path to colour by an unordered attribute (land-use class, region name, …).
+
+The mapping itself is generic colour work and is a candidate to move into cleopatra alongside ``classify``
+(tracked in ``planning/geolibre-parity/ISSUE-TRACKER.md`` / upstream note); it lives here for now because no
+cleopatra equivalent exists yet.
+"""
+
+from typing import Any, List, Tuple
+
+import numpy as np
+
+#: Default qualitative colormap for categorical symbology (10 distinct hues; cycled if more categories).
+_DEFAULT_CATEGORICAL_CMAP = "tab10"
+
+
+def _categories(values: Any) -> List[Any]:
+    """Return the distinct, non-null values of ``values`` in a stable order (sorted when sortable).
+
+    Args:
+        values: An array-like of category labels (strings or numbers); ``None``/``NaN`` are dropped.
+
+    Returns:
+        The unique categories, sorted ascending when they are mutually comparable, else in first-seen order.
+    """
+    seen: List[Any] = []
+    for value in np.asarray(values, dtype=object).ravel():
+        if value is None:
+            continue
+        if isinstance(value, float) and np.isnan(value):
+            continue
+        if value not in seen:
+            seen.append(value)
+    try:
+        return sorted(seen)
+    except TypeError:  # mixed/unsortable types — keep first-seen order
+        return seen
+
+
+def categorical_colors(
+    values: Any, cmap: str = _DEFAULT_CATEGORICAL_CMAP
+) -> Tuple[List[Any], List[str]]:
+    """Map the distinct values of a field to colours from a qualitative colormap (DC.8).
+
+    The categorical analog of ``cleopatra.styles.classify``: instead of binning a continuous range, it assigns
+    one colour per distinct value. Colours cycle through ``cmap`` when there are more categories than the
+    colormap has entries.
+
+    Args:
+        values: An array-like of category labels (strings or numbers); ``None``/``NaN`` are ignored.
+        cmap: A matplotlib (preferably qualitative) colormap name, e.g. ``"tab10"``/``"tab20"``/``"Set2"``.
+
+    Returns:
+        tuple[list, list[str]]: ``(categories, colors)`` — the distinct categories (sorted when sortable) and a
+        ``#rrggbb`` hex colour per category, aligned by index.
+
+    Raises:
+        ValueError: if there are no non-null values to colour.
+
+    Examples:
+        - Distinct string categories get distinct colours:
+            ```python
+            >>> from digitalearth._symbology import categorical_colors
+            >>> cats, colors = categorical_colors(["a", "b", "a", "c"])
+            >>> cats
+            ['a', 'b', 'c']
+            >>> len(colors) == 3 and all(c.startswith("#") for c in colors)
+            True
+
+            ```
+        - More categories than the colormap → colours cycle (never runs out):
+            ```python
+            >>> from digitalearth._symbology import categorical_colors
+            >>> cats, colors = categorical_colors(list(range(12)), cmap="tab10")
+            >>> len(colors)
+            12
+
+            ```
+    """
+    from matplotlib import colormaps
+    from matplotlib.colors import to_hex
+
+    categories = _categories(values)
+    if not categories:
+        raise ValueError("no non-null values to colour categorically")
+    colormap = colormaps[cmap]
+    n_colors = getattr(colormap, "N", len(categories)) or len(categories)
+    colors = [to_hex(colormap(i % n_colors)) for i in range(len(categories))]
+    return categories, colors

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -69,12 +69,14 @@ def _categories(values: Any) -> List[Any]:
         The unique categories, sorted ascending when they are mutually comparable, else in first-seen order.
     """
     seen: List[Any] = []
+    seen_set: set = set()  # O(1) membership so dedup stays O(n), not O(n·k), for large columns
     for value in np.asarray(values, dtype=object).ravel():
         if value is None:
             continue
         if isinstance(value, float) and np.isnan(value):
             continue
-        if value not in seen:
+        if value not in seen_set:
+            seen_set.add(value)
             seen.append(value)
     try:
         return sorted(seen)

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -26,6 +26,10 @@ def _column_or_array(data: Any, value: Any) -> Optional[np.ndarray]:
     column is read as ``float64``; otherwise ``value`` is coerced with ``numpy.asarray`` (and ``None`` passes
     through, so optional ``color_by``/``size_by`` stay absent).
 
+    Use this for *paired* inputs that must stay index-aligned and may legitimately contain non-finite values
+    (scatter ``x``/``y``/``color_by``/``size_by``). For a *single* field reduced to its finite values (histogram
+    / :func:`statistics`), use :func:`_field_values` instead.
+
     Args:
         data: A (Geo)DataFrame whose columns ``value`` may name, or ``None``.
         value: A column name (resolved against ``data``) or an array-like, or ``None``.
@@ -63,6 +67,10 @@ def _field_values(data: Any, column: Optional[str] = None) -> np.ndarray:
     The single field-extraction recipe the column-aware chart helpers share: a GeoDataFrame/DataFrame column
     (when ``column`` is given), a pyramids ``Dataset`` band, or a plain array — always reduced to its finite
     (non-``NaN``/non-``inf``) values as ``float64``.
+
+    Use this for a *single* field that is summarised or binned on its own (histogram, :func:`statistics`). For
+    *paired* inputs that must keep their (possibly non-finite) entries index-aligned, use
+    :func:`_column_or_array` instead.
 
     Args:
         data: A GeoDataFrame/DataFrame (with ``column``), a pyramids ``Dataset``, or an array-like.
@@ -148,7 +156,9 @@ def statistics(
         "std": float(arr.std()),
     }
     for q in quantiles:
-        summary[f"q{int(round(q * 100))}"] = float(np.quantile(arr, q))
+        # ``:g`` keeps integer percents clean (0.25 -> "q25") while still distinguishing fractional
+        # quantiles (0.5 -> "q50", 0.505 -> "q50.5"), so near-equal quantiles do not collide on one key.
+        summary[f"q{q * 100:g}"] = float(np.quantile(arr, q))
     return summary
 
 
@@ -384,7 +394,14 @@ def _grouped_series(data: Any, by: str, column: Optional[str], agg: str):
         raise TypeError("bar_by/line_by need a (Geo)DataFrame with a groupby method")
     grouped = data.groupby(by)
     series = grouped.size() if column is None else grouped[column].agg(agg)
-    return list(series.index), np.asarray(series.to_numpy(), dtype=float)
+    try:
+        values = np.asarray(series.to_numpy(), dtype=float)
+    except (TypeError, ValueError) as err:  # non-numeric aggregate (e.g. agg="sum" on strings)
+        raise TypeError(
+            f"cannot aggregate column {column!r} with agg={agg!r} into numbers — is the column numeric? "
+            f"({err})"
+        ) from err
+    return list(series.index), values
 
 
 def bar_by(data: Any, by: str, column: Optional[str] = None, *, agg: str = "sum",

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -261,7 +261,8 @@ def histogram(values: Any, *, column: Optional[str] = None, bins: int = 15,
         values: A 1-D/2-D sequence of numbers, a pyramids ``Dataset`` (its first band is used, with nodata
             and non-finite cells dropped), or a GeoDataFrame/DataFrame when ``column`` is given (the one-call
             ``histogram(gdf, column="pop")`` field path, DC.1). A 2-D array draws one overlaid histogram per
-            column.
+            column. Non-finite (``NaN``/``inf``) values are dropped on the 1-D and ``column``/``Dataset``
+            paths; a 2-D array keeps its shape (drop non-finite yourself before passing a 2-D array with gaps).
         column: Attribute/column name to histogram when ``values`` is a (Geo)DataFrame; its finite values are
             used.
         bins: Number of histogram bins.
@@ -314,7 +315,14 @@ def histogram(values: Any, *, column: Optional[str] = None, bins: int = 15,
 
             ```
     """
-    arr = _field_values(values, column) if column is not None else _as_finite_array(values)
+    if column is not None:
+        arr = _field_values(values, column)
+    else:
+        arr = _as_finite_array(values)
+        if arr.ndim == 1:
+            # Drop NaN/inf on the 1-D raw path so a raw array with non-finite values histograms cleanly
+            # (a 2-D array keeps its shape for the overlaid-per-column case, so it is left untouched).
+            arr = finite(arr)
     glyph = StatisticalGlyph(arr, ax=ax, fig=_fig_of(ax))
     return glyph.histogram(bins=bins, **kwargs)
 

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -16,7 +16,7 @@ from matplotlib.axes import Axes
 from digitalearth._arrays import fig_of as _fig_of
 from digitalearth._arrays import finite, read_masked_band
 
-__all__ = ["line", "bar", "histogram", "scatter", "statistics"]
+__all__ = ["line", "bar", "bar_by", "line_by", "histogram", "scatter", "statistics"]
 
 
 def _column_or_array(data: Any, value: Any) -> Optional[np.ndarray]:
@@ -362,3 +362,129 @@ def scatter(x: Any, y: Any, *, data: Any = None, color_by: Any = None, size_by: 
     glyph = ScatterGlyph(xs, ys, values=values, sizes=sizes, ax=ax, fig=_fig_of(ax), **kwargs)
     _, ax, _ = glyph.plot(ax=ax)
     return ax
+
+
+def _grouped_series(data: Any, by: str, column: Optional[str], agg: str):
+    """Group ``data`` by ``by`` and aggregate ``column`` (or count rows) — the bar/line-by recipe.
+
+    Args:
+        data: A (Geo)DataFrame to group.
+        by: Column to group on (a category or time field).
+        column: Value column to aggregate; ``None`` counts rows per group.
+        agg: Aggregation name applied to ``column`` (``"sum"``/``"mean"``/``"count"``/``"min"``/…).
+
+    Returns:
+        tuple: ``(keys, values)`` — the group keys (sorted ascending by pandas) and the aggregated values as
+        a ``float64`` array.
+
+    Raises:
+        TypeError: if ``data`` has no ``groupby`` (not a DataFrame).
+    """
+    if not hasattr(data, "groupby"):
+        raise TypeError("bar_by/line_by need a (Geo)DataFrame with a groupby method")
+    grouped = data.groupby(by)
+    series = grouped.size() if column is None else grouped[column].agg(agg)
+    return list(series.index), np.asarray(series.to_numpy(), dtype=float)
+
+
+def bar_by(data: Any, by: str, column: Optional[str] = None, *, agg: str = "sum",
+           ax: Optional[Axes] = None, **kwargs) -> Axes:
+    """Bar chart of an aggregate per category (DC.4).
+
+    Groups ``data`` by the ``by`` column and draws one bar per group of ``column`` aggregated with ``agg``
+    (or the row count when ``column`` is ``None``). Bars sit at integer positions labelled with the category
+    names, so non-numeric categories render correctly.
+
+    Args:
+        data: A (Geo)DataFrame.
+        by: Category column to group on.
+        column: Value column to aggregate; ``None`` counts rows per category.
+        agg: Aggregation name (``"sum"``/``"mean"``/``"count"``/``"min"``/``"max"``/``"median"``).
+        ax: Existing axes to draw on; a new figure/axes is created when ``None``.
+        **kwargs: Forwarded to :func:`bar` (e.g. ``color``, ``width``).
+
+    Returns:
+        The :class:`matplotlib.axes.Axes` with one bar per category, x-tick-labelled by category.
+
+    Examples:
+        - Sum a value column per category:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from digitalearth.charts import bar_by
+            >>> gdf = gpd.GeoDataFrame(
+            ...     {"cat": ["a", "a", "b"], "v": [1.0, 2.0, 3.0]},
+            ...     geometry=[Point(i, i) for i in range(3)],
+            ...     crs=4326,
+            ... )
+            >>> ax = bar_by(gdf, "cat", "v", agg="sum")
+            >>> [round(rect.get_height(), 1) for rect in ax.containers[0]]
+            [3.0, 3.0]
+
+            ```
+        - Count rows per category (no value column):
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from digitalearth.charts import bar_by
+            >>> gdf = gpd.GeoDataFrame(
+            ...     {"cat": ["a", "a", "b"]},
+            ...     geometry=[Point(i, i) for i in range(3)],
+            ...     crs=4326,
+            ... )
+            >>> ax = bar_by(gdf, "cat")
+            >>> [int(rect.get_height()) for rect in ax.containers[0]]
+            [2, 1]
+
+            ```
+    """
+    keys, values = _grouped_series(data, by, column, agg)
+    ax = bar(range(len(keys)), values, ax=ax, **kwargs)
+    ax.set_xticks(range(len(keys)))
+    ax.set_xticklabels([str(key) for key in keys])
+    return ax
+
+
+def line_by(data: Any, by: str, column: Optional[str] = None, *, agg: str = "sum",
+            ax: Optional[Axes] = None, **kwargs) -> Axes:
+    """Line chart of an aggregate per ordered key — e.g. a value summed by year (DC.4).
+
+    Groups ``data`` by the ``by`` column (typically a time/ordered field), aggregates ``column`` with ``agg``
+    (or counts rows when ``column`` is ``None``), and draws a line over the sorted keys.
+
+    Args:
+        data: A (Geo)DataFrame.
+        by: Ordered/time column to group on (kept in ascending key order).
+        column: Value column to aggregate; ``None`` counts rows per key.
+        agg: Aggregation name (``"sum"``/``"mean"``/``"count"``/…).
+        ax: Existing axes to draw on; a new figure/axes is created when ``None``.
+        **kwargs: Forwarded to :func:`line` (e.g. ``label``, ``color``, ``marker``).
+
+    Returns:
+        The :class:`matplotlib.axes.Axes` with the aggregated series as one line.
+
+    Examples:
+        - Mean of a value by year:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from digitalearth.charts import line_by
+            >>> gdf = gpd.GeoDataFrame(
+            ...     {"year": [2000, 2000, 2010], "v": [1.0, 3.0, 5.0]},
+            ...     geometry=[Point(i, i) for i in range(3)],
+            ...     crs=4326,
+            ... )
+            >>> ax = line_by(gdf, "year", "v", agg="mean")
+            >>> len(ax.lines)
+            1
+
+            ```
+    """
+    keys, values = _grouped_series(data, by, column, agg)
+    return line(keys, values, ax=ax, **kwargs)

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -99,7 +99,9 @@ def statistics(
 
     A thin numpy reduction (not a GIS op): the input is coerced to its finite values and summarised. Accepts a
     GeoDataFrame/DataFrame with ``column``, a pyramids ``Dataset`` (first band, nodata dropped), or a plain
-    array. Quantiles are returned under ``q<pct>`` keys (e.g. ``q50`` for the median).
+    array. Quantiles are returned under ``q<pct>`` keys (e.g. ``q50`` for the median); the percent is formatted
+    with ``:g``, so fractional quantiles stay distinct (``q50`` vs ``q50.5``) but two quantiles closer than
+    ~1e-6 would share a key.
 
     Args:
         data: A (Geo)DataFrame (with ``column``), a pyramids ``Dataset``, or an array-like of numbers.

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -437,7 +437,7 @@ def bar_by(data: Any, by: str, column: Optional[str] = None, *, agg: str = "sum"
             ...     crs=4326,
             ... )
             >>> ax = bar_by(gdf, "cat", "v", agg="sum")
-            >>> [round(rect.get_height(), 1) for rect in ax.containers[0]]
+            >>> [float(round(rect.get_height(), 1)) for rect in ax.containers[0]]
             [3.0, 3.0]
 
             ```

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -5,7 +5,7 @@ histogram. The rendering lives in cleopatra (``LineGlyph``, ``StatisticalGlyph``
 numpy arrays (or a pyramids ``Dataset`` band, with nodata dropped) into the inputs those glyphs expect.
 Parallel to :mod:`digitalearth.series` (the ensemble/statistical series plots).
 """
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import numpy as np
 from cleopatra.line_glyph import LineGlyph
@@ -15,7 +15,7 @@ from matplotlib.axes import Axes
 from digitalearth._arrays import fig_of as _fig_of
 from digitalearth._arrays import finite, read_masked_band
 
-__all__ = ["line", "bar", "histogram"]
+__all__ = ["line", "bar", "histogram", "statistics"]
 
 
 def _as_finite_array(values: Any) -> np.ndarray:
@@ -28,6 +28,101 @@ def _as_finite_array(values: Any) -> np.ndarray:
     if hasattr(values, "read_array") and hasattr(values, "no_data_value"):
         return finite(read_masked_band(values, band=1))
     return np.asarray(values)
+
+
+def _field_values(data: Any, column: Optional[str] = None) -> np.ndarray:
+    """Return the finite, flattened 1-D values of a *field*.
+
+    The single field-extraction recipe the column-aware chart helpers share: a GeoDataFrame/DataFrame column
+    (when ``column`` is given), a pyramids ``Dataset`` band, or a plain array — always reduced to its finite
+    (non-``NaN``/non-``inf``) values as ``float64``.
+
+    Args:
+        data: A GeoDataFrame/DataFrame (with ``column``), a pyramids ``Dataset``, or an array-like.
+        column: Attribute/column name to read when ``data`` is a (Geo)DataFrame.
+
+    Returns:
+        numpy.ndarray: the finite values as a 1-D ``float64`` array.
+
+    Raises:
+        KeyError: if ``column`` is given but absent from ``data``.
+    """
+    if column is not None and hasattr(data, "columns"):
+        if column not in data.columns:
+            raise KeyError(f"column {column!r} not found in the feature attributes")
+        return finite(np.asarray(data[column], dtype=float))
+    return finite(_as_finite_array(data))
+
+
+def statistics(
+    data: Any,
+    *,
+    column: Optional[str] = None,
+    quantiles: Sequence[float] = (0.25, 0.5, 0.75),
+) -> dict:
+    """Summarise a field — count/min/max/mean/std plus the requested quantiles (DC.5).
+
+    A thin numpy reduction (not a GIS op): the input is coerced to its finite values and summarised. Accepts a
+    GeoDataFrame/DataFrame with ``column``, a pyramids ``Dataset`` (first band, nodata dropped), or a plain
+    array. Quantiles are returned under ``q<pct>`` keys (e.g. ``q50`` for the median).
+
+    Args:
+        data: A (Geo)DataFrame (with ``column``), a pyramids ``Dataset``, or an array-like of numbers.
+        column: Attribute/column name to summarise when ``data`` is a (Geo)DataFrame.
+        quantiles: Quantiles in ``[0, 1]`` to include (default the quartiles ``0.25``/``0.5``/``0.75``).
+
+    Returns:
+        dict: ``count`` (int) plus ``min``/``max``/``mean``/``std`` and one ``q<pct>`` entry per quantile,
+        all floats.
+
+    Raises:
+        ValueError: if there are no finite values to summarise.
+        KeyError: if ``column`` is given but absent from ``data``.
+
+    Examples:
+        - Summarise a plain sequence (median is ``q50``):
+            ```python
+            >>> from digitalearth.charts import statistics
+            >>> s = statistics([1, 2, 3, 4])
+            >>> (s["count"], s["min"], s["max"], s["mean"], s["q50"])
+            (4, 1.0, 4.0, 2.5, 2.5)
+
+            ```
+        - Summarise a GeoDataFrame column:
+            ```python
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from digitalearth.charts import statistics
+            >>> gdf = gpd.GeoDataFrame(
+            ...     {"pop": [10.0, 20.0, 30.0]},
+            ...     geometry=[Point(i, i) for i in range(3)],
+            ...     crs=4326,
+            ... )
+            >>> statistics(gdf, column="pop")["mean"]
+            20.0
+
+            ```
+        - Pick custom quantiles:
+            ```python
+            >>> from digitalearth.charts import statistics
+            >>> sorted(statistics(range(101), quantiles=(0.1, 0.9)))
+            ['count', 'max', 'mean', 'min', 'q10', 'q90', 'std']
+
+            ```
+    """
+    arr = _field_values(data, column)
+    if arr.size == 0:
+        raise ValueError("no finite values to summarise")
+    summary: dict = {
+        "count": int(arr.size),
+        "min": float(arr.min()),
+        "max": float(arr.max()),
+        "mean": float(arr.mean()),
+        "std": float(arr.std()),
+    }
+    for q in quantiles:
+        summary[f"q{int(round(q * 100))}"] = float(np.quantile(arr, q))
+    return summary
 
 
 def line(x: Any, y: Any, *, ax: Optional[Axes] = None, label: Any = None, color: Any = None,

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -209,12 +209,17 @@ def bar(x: Any, heights: Any, *, ax: Optional[Axes] = None, color: Any = None, *
     return ax
 
 
-def histogram(values: Any, *, bins: int = 15, ax: Optional[Axes] = None, **kwargs):
-    """Draw a histogram of array or raster values (cleopatra ``StatisticalGlyph.histogram``).
+def histogram(values: Any, *, column: Optional[str] = None, bins: int = 15,
+              ax: Optional[Axes] = None, **kwargs):
+    """Draw a histogram of array, raster, or field values (cleopatra ``StatisticalGlyph.histogram``).
 
     Args:
-        values: A 1-D/2-D sequence of numbers, or a pyramids ``Dataset`` (its first band is used, with nodata
-            and non-finite cells dropped). A 2-D array draws one overlaid histogram per column.
+        values: A 1-D/2-D sequence of numbers, a pyramids ``Dataset`` (its first band is used, with nodata
+            and non-finite cells dropped), or a GeoDataFrame/DataFrame when ``column`` is given (the one-call
+            ``histogram(gdf, column="pop")`` field path, DC.1). A 2-D array draws one overlaid histogram per
+            column.
+        column: Attribute/column name to histogram when ``values`` is a (Geo)DataFrame; its finite values are
+            used.
         bins: Number of histogram bins.
         ax: Existing axes to draw on; a new figure/axes is created when ``None``.
         **kwargs: Forwarded to ``StatisticalGlyph.histogram`` (e.g. ``color``, ``alpha``, ``rwidth``).
@@ -247,7 +252,24 @@ def histogram(values: Any, *, bins: int = 15, ax: Optional[Axes] = None, **kwarg
             4
 
             ```
+        - A GeoDataFrame column is histogrammed in one call (DC.1):
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from digitalearth.charts import histogram
+            >>> gdf = gpd.GeoDataFrame(
+            ...     {"pop": [1.0, 1.0, 2.0, 3.0]},
+            ...     geometry=[Point(i, i) for i in range(4)],
+            ...     crs=4326,
+            ... )
+            >>> fig, ax, hist = histogram(gdf, column="pop", bins=3)
+            >>> len(ax.patches)
+            3
+
+            ```
     """
-    arr = _as_finite_array(values)
+    arr = _field_values(values, column) if column is not None else _as_finite_array(values)
     glyph = StatisticalGlyph(arr, ax=ax, fig=_fig_of(ax))
     return glyph.histogram(bins=bins, **kwargs)

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -408,10 +408,13 @@ def _grouped_series(data: Any, by: str, column: Optional[str], agg: str):
     if not hasattr(data, "groupby"):
         raise TypeError("bar_by/line_by need a (Geo)DataFrame with a groupby method")
     grouped = data.groupby(by)
-    series = grouped.size() if column is None else grouped[column].agg(agg)
     try:
+        # The agg itself can raise for a non-numeric column (mean/median/std reject strings), and a
+        # numeric-looking agg that succeeds (sum/min/max concatenate/compare strings) fails the float cast —
+        # wrap both so every non-numeric aggregation surfaces the same actionable message.
+        series = grouped.size() if column is None else grouped[column].agg(agg)
         values = np.asarray(series.to_numpy(), dtype=float)
-    except (TypeError, ValueError) as err:  # non-numeric aggregate (e.g. agg="sum" on strings)
+    except (TypeError, ValueError) as err:
         raise TypeError(
             f"cannot aggregate column {column!r} with agg={agg!r} into numbers — is the column numeric? "
             f"({err})"

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -100,8 +100,8 @@ def statistics(
     A thin numpy reduction (not a GIS op): the input is coerced to its finite values and summarised. Accepts a
     GeoDataFrame/DataFrame with ``column``, a pyramids ``Dataset`` (first band, nodata dropped), or a plain
     array. Quantiles are returned under ``q<pct>`` keys (e.g. ``q50`` for the median); the percent is formatted
-    with ``:g``, so fractional quantiles stay distinct (``q50`` vs ``q50.5``) but two quantiles closer than
-    ~1e-6 would share a key.
+    with ``:g``, so fractional quantiles stay distinct (``q50`` vs ``q50.5``). Two quantiles that differ only
+    below ~1e-6 would format to the same key and raise ``ValueError`` rather than silently overwrite.
 
     Args:
         data: A (Geo)DataFrame (with ``column``), a pyramids ``Dataset``, or an array-like of numbers.
@@ -113,7 +113,7 @@ def statistics(
         all floats.
 
     Raises:
-        ValueError: if there are no finite values to summarise.
+        ValueError: if there are no finite values to summarise, or if two quantiles collide on one key.
         KeyError: if ``column`` is given but absent from ``data``.
 
     Examples:
@@ -160,7 +160,12 @@ def statistics(
     for q in quantiles:
         # ``:g`` keeps integer percents clean (0.25 -> "q25") while still distinguishing fractional
         # quantiles (0.5 -> "q50", 0.505 -> "q50.5"), so near-equal quantiles do not collide on one key.
-        summary[f"q{q * 100:g}"] = float(np.quantile(arr, q))
+        key = f"q{q * 100:g}"
+        if key in summary:
+            # Two quantiles that format to the same key (differing only below ~1e-6) would silently
+            # overwrite each other — surface it instead.
+            raise ValueError(f"quantiles collide on key {key!r}; use quantiles that differ by more than ~1e-6")
+        summary[key] = float(np.quantile(arr, q))
     return summary
 
 

--- a/src/digitalearth/charts.py
+++ b/src/digitalearth/charts.py
@@ -9,13 +9,40 @@ from typing import Any, Optional, Sequence
 
 import numpy as np
 from cleopatra.line_glyph import LineGlyph
+from cleopatra.scatter_glyph import ScatterGlyph
 from cleopatra.statistical_glyph import StatisticalGlyph
 from matplotlib.axes import Axes
 
 from digitalearth._arrays import fig_of as _fig_of
 from digitalearth._arrays import finite, read_masked_band
 
-__all__ = ["line", "bar", "histogram", "statistics"]
+__all__ = ["line", "bar", "histogram", "scatter", "statistics"]
+
+
+def _column_or_array(data: Any, value: Any) -> Optional[np.ndarray]:
+    """Resolve ``value`` to an array — a column of ``data`` when it names one, else array-like as-is.
+
+    The field-vs-field plumbing: with a (Geo)DataFrame ``data`` and a string ``value`` naming a column, the
+    column is read as ``float64``; otherwise ``value`` is coerced with ``numpy.asarray`` (and ``None`` passes
+    through, so optional ``color_by``/``size_by`` stay absent).
+
+    Args:
+        data: A (Geo)DataFrame whose columns ``value`` may name, or ``None``.
+        value: A column name (resolved against ``data``) or an array-like, or ``None``.
+
+    Returns:
+        The resolved array, or ``None`` when ``value`` is ``None``.
+
+    Raises:
+        KeyError: if ``value`` names a column absent from ``data``.
+    """
+    if value is None:
+        return None
+    if data is not None and isinstance(value, str) and hasattr(data, "columns"):
+        if value not in data.columns:
+            raise KeyError(f"column {value!r} not found in the feature attributes")
+        return np.asarray(data[value], dtype=float)
+    return np.asarray(value)
 
 
 def _as_finite_array(values: Any) -> np.ndarray:
@@ -273,3 +300,65 @@ def histogram(values: Any, *, column: Optional[str] = None, bins: int = 15,
     arr = _field_values(values, column) if column is not None else _as_finite_array(values)
     glyph = StatisticalGlyph(arr, ax=ax, fig=_fig_of(ax))
     return glyph.histogram(bins=bins, **kwargs)
+
+
+def scatter(x: Any, y: Any, *, data: Any = None, color_by: Any = None, size_by: Any = None,
+            ax: Optional[Axes] = None, **kwargs) -> Axes:
+    """Draw a field-vs-field scatter (cleopatra ``ScatterGlyph``); returns the Axes (DC.3).
+
+    Plots ``y`` against ``x`` as a point cloud, optionally colouring points by ``color_by`` and sizing them by
+    ``size_by``. With a (Geo)DataFrame ``data``, ``x``/``y``/``color_by``/``size_by`` may be column names;
+    otherwise they are array-likes.
+
+    Args:
+        x: x values, or a column name of ``data``.
+        y: y values (same length as ``x``), or a column name of ``data``.
+        data: Optional (Geo)DataFrame; when given, the other arguments may name its columns.
+        color_by: Optional values (or column name) mapped to point colour (adds a colorbar).
+        size_by: Optional magnitudes (or column name) mapped to point size.
+        ax: Existing axes to draw on; a new figure/axes is created when ``None``.
+        **kwargs: Forwarded to ``ScatterGlyph`` (e.g. ``cmap``, ``point_size``, ``vmin``, ``vmax``, ``alpha``).
+
+    Returns:
+        The :class:`matplotlib.axes.Axes` the scatter was drawn on (one ``PathCollection``).
+
+    Raises:
+        KeyError: if a column name is given but absent from ``data``.
+        ValueError: if ``x`` and ``y`` differ in shape (from ``ScatterGlyph``).
+
+    Examples:
+        - Two arrays draw one scatter collection:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> from digitalearth.charts import scatter
+            >>> ax = scatter([1, 2, 3], [4, 5, 6])
+            >>> len(ax.collections)
+            1
+
+            ```
+        - Field vs field from a GeoDataFrame by column name:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from digitalearth.charts import scatter
+            >>> gdf = gpd.GeoDataFrame(
+            ...     {"a": [1.0, 2.0, 3.0], "b": [3.0, 2.0, 1.0]},
+            ...     geometry=[Point(i, i) for i in range(3)],
+            ...     crs=4326,
+            ... )
+            >>> ax = scatter("a", "b", data=gdf)
+            >>> len(ax.collections)
+            1
+
+            ```
+    """
+    xs = _column_or_array(data, x)
+    ys = _column_or_array(data, y)
+    values = _column_or_array(data, color_by)
+    sizes = _column_or_array(data, size_by)
+    glyph = ScatterGlyph(xs, ys, values=values, sizes=sizes, ax=ax, fig=_fig_of(ax), **kwargs)
+    _, ax, _ = glyph.plot(ax=ax)
+    return ax

--- a/src/digitalearth/interactive/base.py
+++ b/src/digitalearth/interactive/base.py
@@ -137,6 +137,9 @@ class InteractiveMapBase:
         self._projection: Any = None
         # Draw-tool stream (DI.8), set by the interaction mixin's draw(); None until a draw tool is added.
         self._draw_stream: Any = None
+        # Class breaks / categories from the most recent choropleth, for building a legend out-of-band
+        # (web-tier parity). None until a categorical choropleth runs; the continuous ramp resets it to None.
+        self.last_breaks: Optional[List[Any]] = None
         self.layers: List[Any] = []
 
     def _raster_element(self, x: Any, y: Any, arr: Any, name: str) -> Any:

--- a/src/digitalearth/interactive/charts.py
+++ b/src/digitalearth/interactive/charts.py
@@ -14,7 +14,7 @@ from typing import Any, Optional, Sequence
 
 import numpy as np
 
-from digitalearth.charts import _as_finite_array, _column_or_array, _field_values, _grouped_series
+from digitalearth.charts import _column_or_array, _field_values, _grouped_series
 
 __all__ = ["histogram", "scatter", "bar", "line", "bar_by", "line_by"]
 
@@ -52,7 +52,9 @@ def histogram(data: Any, *, column: Optional[str] = None, bins: int = 15, **opts
         ImportError: when the ``interactive`` extra is not installed.
     """
     hv = _require_holoviews()
-    values = _field_values(data, column) if column is not None else _as_finite_array(data).ravel()
+    # _field_values drops non-finite (NaN/inf) values on every path (column, Dataset band or plain array),
+    # so a raw array with NaN yields a clean histogram instead of an opaque numpy range error.
+    values = _field_values(data, column)
     element = hv.Histogram(np.histogram(values, bins=bins))
     return element.opts(**opts) if opts else element
 

--- a/src/digitalearth/interactive/charts.py
+++ b/src/digitalearth/interactive/charts.py
@@ -1,0 +1,161 @@
+"""Interactive (HoloViz / Bokeh) charts — the interactive-tier counterpart of :mod:`digitalearth.charts` (DC.6).
+
+``digitalearth.charts`` renders static matplotlib charts via cleopatra; these return **HoloViews elements**
+(``hv.Histogram`` / ``hv.Scatter`` / ``hv.Bars`` / ``hv.Curve``) for pan/zoom/hover charts in the interactive
+tier — surfacing DC.1 (histogram), DC.3 (scatter) and DC.4 (aggregate bar/line) on the HoloViz stack. The
+field-extraction and aggregation logic is shared with :mod:`digitalearth.charts` (one source of truth); only
+the rendering engine differs.
+
+holoviews is imported lazily (the optional ``interactive`` extra): importing this module needs no engine; only
+calling a chart builder does, and a missing extra raises an actionable :class:`ImportError`.
+"""
+
+from typing import Any, Optional, Sequence
+
+import numpy as np
+
+from digitalearth.charts import _as_finite_array, _column_or_array, _field_values, _grouped_series
+
+__all__ = ["histogram", "scatter", "bar", "line", "bar_by", "line_by"]
+
+_INSTALL_HINT = (
+    "the interactive charts need the HoloViz stack (holoviews). "
+    "Install it with `pip install 'digitalearth[interactive]'` (or, in this repo, `pixi install -e interactive`)."
+)
+
+
+def _require_holoviews():
+    """Import and return ``holoviews`` (Bokeh backend registered), raising an actionable error when absent."""
+    try:
+        import holoviews as hv
+    except ImportError as err:
+        raise ImportError(_INSTALL_HINT) from err
+    if "bokeh" not in hv.Store.renderers:
+        hv.renderer("bokeh")
+    return hv
+
+
+def histogram(data: Any, *, column: Optional[str] = None, bins: int = 15, **opts: Any) -> Any:
+    """Interactive histogram of a field (``hv.Histogram``) — the HoloViz DC.1 (DC.6).
+
+    Args:
+        data: A 1-D array, a pyramids ``Dataset`` (first band, nodata dropped), or a (Geo)DataFrame with
+            ``column``.
+        column: Attribute column to histogram when ``data`` is a (Geo)DataFrame.
+        bins: Number of histogram bins.
+        **opts: HoloViews options applied to the element (e.g. ``color``, ``width``, ``height``, ``alpha``).
+
+    Returns:
+        An ``hv.Histogram`` of the binned counts.
+
+    Raises:
+        ImportError: when the ``interactive`` extra is not installed.
+    """
+    hv = _require_holoviews()
+    values = _field_values(data, column) if column is not None else _as_finite_array(data).ravel()
+    element = hv.Histogram(np.histogram(values, bins=bins))
+    return element.opts(**opts) if opts else element
+
+
+def scatter(x: Any, y: Any, *, data: Any = None, **opts: Any) -> Any:
+    """Interactive field-vs-field scatter (``hv.Scatter``) — the HoloViz DC.3 (DC.6).
+
+    Args:
+        x: x values, or a column name of ``data``.
+        y: y values (same length as ``x``), or a column name of ``data``.
+        data: Optional (Geo)DataFrame; when given, ``x``/``y`` may name its columns.
+        **opts: HoloViews options applied to the element (e.g. ``size``, ``color``, ``tools``).
+
+    Returns:
+        An ``hv.Scatter`` of ``y`` against ``x``.
+
+    Raises:
+        ImportError: when the ``interactive`` extra is not installed.
+    """
+    hv = _require_holoviews()
+    xs = _column_or_array(data, x)
+    ys = _column_or_array(data, y)
+    element = hv.Scatter((xs, ys))
+    return element.opts(**opts) if opts else element
+
+
+def bar(x: Any, heights: Any, **opts: Any) -> Any:
+    """Interactive bar chart of a single series (``hv.Bars``).
+
+    Args:
+        x: 1-D bar positions / categories.
+        heights: Bar heights, the same length as ``x``.
+        **opts: HoloViews options applied to the element.
+
+    Returns:
+        An ``hv.Bars`` element.
+
+    Raises:
+        ImportError: when the ``interactive`` extra is not installed.
+    """
+    hv = _require_holoviews()
+    element = hv.Bars((list(x), np.asarray(heights)))
+    return element.opts(**opts) if opts else element
+
+
+def line(x: Any, y: Any, **opts: Any) -> Any:
+    """Interactive x–y line series (``hv.Curve``).
+
+    Args:
+        x: 1-D x coordinates.
+        y: 1-D y values, the same length as ``x``.
+        **opts: HoloViews options applied to the element.
+
+    Returns:
+        An ``hv.Curve`` element.
+
+    Raises:
+        ImportError: when the ``interactive`` extra is not installed.
+    """
+    hv = _require_holoviews()
+    element = hv.Curve((np.asarray(x), np.asarray(y)))
+    return element.opts(**opts) if opts else element
+
+
+def bar_by(data: Any, by: str, column: Optional[str] = None, *, agg: str = "sum", **opts: Any) -> Any:
+    """Interactive bar chart of an aggregate per category (``hv.Bars``) — the HoloViz DC.4 (DC.6).
+
+    Args:
+        data: A (Geo)DataFrame.
+        by: Category column to group on.
+        column: Value column to aggregate; ``None`` counts rows per category.
+        agg: Aggregation name (``"sum"``/``"mean"``/``"count"``/…).
+        **opts: HoloViews options applied to the element.
+
+    Returns:
+        An ``hv.Bars`` of the aggregate per category.
+
+    Raises:
+        ImportError: when the ``interactive`` extra is not installed.
+    """
+    hv = _require_holoviews()
+    keys, values = _grouped_series(data, by, column, agg)
+    element = hv.Bars(([str(k) for k in keys], values))
+    return element.opts(**opts) if opts else element
+
+
+def line_by(data: Any, by: str, column: Optional[str] = None, *, agg: str = "sum", **opts: Any) -> Any:
+    """Interactive line of an aggregate per ordered/time key (``hv.Curve``) — the HoloViz DC.4 (DC.6).
+
+    Args:
+        data: A (Geo)DataFrame.
+        by: Ordered/time column to group on (kept in ascending key order).
+        column: Value column to aggregate; ``None`` counts rows per key.
+        agg: Aggregation name (``"sum"``/``"mean"``/``"count"``/…).
+        **opts: HoloViews options applied to the element.
+
+    Returns:
+        An ``hv.Curve`` of the aggregate over the sorted keys.
+
+    Raises:
+        ImportError: when the ``interactive`` extra is not installed.
+    """
+    hv = _require_holoviews()
+    keys, values = _grouped_series(data, by, column, agg)
+    element = hv.Curve((keys, values))
+    return element.opts(**opts) if opts else element

--- a/src/digitalearth/interactive/vector.py
+++ b/src/digitalearth/interactive/vector.py
@@ -296,6 +296,8 @@ class VectorMixin:
             column: The column driving the fill colour (required); numeric for the continuous ramp, or any
                 hashable value for ``scheme="categorical"``.
             scheme: ``"categorical"`` for distinct-value colouring; ``None`` (default) for a continuous ramp.
+                Graduated schemes (``"quantiles"``/``"fisher_jenks"``/…) are **not** supported in the
+                interactive tier and raise ``NotImplementedError`` rather than silently degrading.
             cmap: Colormap name (a qualitative map such as ``"tab10"`` is used for the categorical scheme when
                 left at the default).
             clim: Optional ``(vmin, vmax)`` colour limits for the continuous ramp; ``None`` auto-scales.
@@ -318,6 +320,8 @@ class VectorMixin:
 
         Raises:
             KeyError: when ``column`` is not a column of ``features``.
+            NotImplementedError: when ``scheme`` is a graduated scheme (only ``"categorical"``/``None`` are
+                supported in the interactive tier).
         """
         if column not in getattr(features, "columns", [column]):
             raise KeyError(
@@ -325,6 +329,12 @@ class VectorMixin:
             )
         if isinstance(scheme, str) and scheme.lower() == "categorical":
             return self._categorical_polygons(features, column, cmap=cmap, **opts)
+        if scheme is not None:
+            raise NotImplementedError(
+                f"interactive choropleth supports scheme='categorical' or None (continuous ramp); the "
+                f"graduated scheme {scheme!r} is not implemented in the interactive tier — use the web tier "
+                f"for graduated classification, or pass scheme=None for a continuous ramp"
+            )
         # Continuous ramp: no discrete breaks — clear any recorded from a prior categorical call.
         self.last_breaks = None
         if clim is not None:

--- a/src/digitalearth/interactive/vector.py
+++ b/src/digitalearth/interactive/vector.py
@@ -241,9 +241,10 @@ class VectorMixin:
         gets a colour from :func:`digitalearth._symbology.categorical_colors`. The colour column is cast to
         **string** and the colours are handed to GeoViews as a ``{label: colour}`` dict ``cmap`` — a numeric
         column would otherwise be treated as a continuous dimension and the palette interpolated, so this is
-        what guarantees one discrete colour per distinct value (no continuous colorbar). The categories
-        (original values, in classifier order) are recorded on ``last_breaks`` for legend parity with the web
-        tier.
+        what guarantees one discrete colour per distinct value (no continuous colorbar). Missing values
+        (``NaN``/``None``) are drawn with a neutral ``"#cccccc"`` fallback, matching the web tier's default.
+        The categories (original values, in classifier order) are recorded on ``last_breaks`` for legend parity
+        with the web tier.
 
         Args:
             features: A pyramids ``FeatureCollection`` of polygons (reprojected through pyramids).
@@ -261,8 +262,12 @@ class VectorMixin:
         # Render the column as discrete labels and map each label to its colour, so Bokeh colours it
         # categorically (a numeric column would map continuously and interpolate the palette).
         gdf = gdf.copy()
-        gdf[column] = gdf[column].astype(str)
+        missing = gdf[column].isna()
+        gdf[column] = gdf[column].astype(str).mask(missing, "n/a")
         cmap_by_label = {str(category): color for category, color in zip(categories, colors)}
+        if missing.any():
+            # Missing values get an explicit neutral fallback, matching the web tier's "#cccccc" default.
+            cmap_by_label["n/a"] = "#cccccc"
         element = self._vector_element("Polygons", gdf, vdims=[column])
         common = {"color": column, "cmap": cmap_by_label, "colorbar": False, **opts}
         element = self._styled(element, common=common, bokeh={"tools": ["hover"]})

--- a/src/digitalearth/interactive/vector.py
+++ b/src/digitalearth/interactive/vector.py
@@ -259,15 +259,20 @@ class VectorMixin:
 
         gdf = self._display_gdf(features)
         categories, colors = categorical_colors(gdf[column], resolve_categorical_cmap(cmap))
+        cmap_by_label = {str(category): color for category, color in zip(categories, colors)}
         # Render the column as discrete labels and map each label to its colour, so Bokeh colours it
         # categorically (a numeric column would map continuously and interpolate the palette).
         gdf = gdf.copy()
         missing = gdf[column].isna()
-        gdf[column] = gdf[column].astype(str).mask(missing, "n/a")
-        cmap_by_label = {str(category): color for category, color in zip(categories, colors)}
+        # A sentinel label for missing rows that is guaranteed not to collide with a real category (which
+        # could itself stringify to "n/a"/"nan"), so a genuine category is never overwritten by the fallback.
+        sentinel = "n/a"
+        while sentinel in cmap_by_label:
+            sentinel += "_"
+        gdf[column] = gdf[column].astype(str).mask(missing, sentinel)
         if missing.any():
             # Missing values get an explicit neutral fallback, matching the web tier's "#cccccc" default.
-            cmap_by_label["n/a"] = "#cccccc"
+            cmap_by_label[sentinel] = "#cccccc"
         element = self._vector_element("Polygons", gdf, vdims=[column])
         common = {"color": column, "cmap": cmap_by_label, "colorbar": False, **opts}
         element = self._styled(element, common=common, bokeh={"tools": ["hover"]})

--- a/src/digitalearth/interactive/vector.py
+++ b/src/digitalearth/interactive/vector.py
@@ -246,9 +246,14 @@ class VectorMixin:
         The categories (original values, in classifier order) are recorded on ``last_breaks`` for legend parity
         with the web tier.
 
+        Because the fill is keyed on the **string** form of each value, this assumes a single-dtype attribute
+        column: two categories that stringify identically (e.g. the integer ``1`` and the string ``"1"``, or
+        ``1`` and ``1.0``) collapse to one colour. Realistic categorical columns are single-dtype; the web tier
+        keeps such mixed values distinct via its native ``match``.
+
         Args:
             features: A pyramids ``FeatureCollection`` of polygons (reprojected through pyramids).
-            column: The attribute to colour by (any hashable value).
+            column: The attribute to colour by (any hashable value; assumed single-dtype — see above).
             cmap: A qualitative colormap name (defaults to ``"tab10"`` when left at the continuous default).
             **opts: Extra HoloViews style options.
 

--- a/src/digitalearth/interactive/vector.py
+++ b/src/digitalearth/interactive/vector.py
@@ -295,6 +295,10 @@ class VectorMixin:
         ``scheme="categorical"`` to colour an unordered attribute by distinct value instead of a continuous
         ramp (DC.8); the categories are recorded on ``last_breaks`` for legend parity with the web tier.
 
+        Note the default ``scheme`` differs by tier: this interactive tier (like the static ``Map.choropleth``)
+        defaults to a **continuous** ramp, whereas the **web** ``choropleth`` is graduated-by-default
+        (``"quantiles"``). Pass ``scheme`` explicitly for identical classification across tiers.
+
         Args:
             features: A pyramids ``FeatureCollection`` of polygon geometries; reprojected through
                 pyramids when needed.

--- a/src/digitalearth/interactive/vector.py
+++ b/src/digitalearth/interactive/vector.py
@@ -233,25 +233,59 @@ class VectorMixin:
         element = self._styled(element, common=common, bokeh={"tools": ["hover"]})
         return self.add_element(element)
 
+    def _categorical_polygons(self, features: Any, column: str, *, cmap: str = "viridis",
+                              **opts: Any) -> "VectorMixin":
+        """Fill polygons by a distinct-value attribute, one colour per category (DC.8).
+
+        The categorical counterpart of the continuous :meth:`polygons` path: each distinct value of ``column``
+        gets a colour from :func:`digitalearth._symbology.categorical_colors`, passed to GeoViews as a list
+        ``cmap`` over the categorical column (no continuous colorbar). The categories are recorded on
+        ``last_breaks`` for legend parity with the web tier.
+
+        Args:
+            features: A pyramids ``FeatureCollection`` of polygons (reprojected through pyramids).
+            column: The attribute to colour by (any hashable value).
+            cmap: A qualitative colormap name (defaults to ``"tab10"`` when left at the continuous default).
+            **opts: Extra HoloViews style options.
+
+        Returns:
+            This map (chainable).
+        """
+        from digitalearth._symbology import categorical_colors
+
+        gdf = self._display_gdf(features)
+        categories, colors = categorical_colors(gdf[column], "tab10" if cmap == "viridis" else cmap)
+        element = self._vector_element("Polygons", gdf, vdims=[column])
+        common = {"color": column, "cmap": colors, "colorbar": False, **opts}
+        element = self._styled(element, common=common, bokeh={"tools": ["hover"]})
+        self.last_breaks = list(categories)
+        return self.add_element(element)
+
     def choropleth(
         self,
         features: Any,
         column: str,
         *,
+        scheme: Optional[str] = None,
         cmap: str = "viridis",
         clim: Optional[Tuple[float, float]] = None,
         **opts: Any,
     ) -> "VectorMixin":
         """Add a choropleth — polygons filled and coloured by ``column`` (hover shows the value).
 
-        A thin colour-by-attribute :meth:`polygons`, mirroring the static ``Map.choropleth``.
+        A thin colour-by-attribute :meth:`polygons`, mirroring the static ``Map.choropleth``. Pass
+        ``scheme="categorical"`` to colour an unordered attribute by distinct value instead of a continuous
+        ramp (DC.8); the categories are recorded on ``last_breaks`` for legend parity with the web tier.
 
         Args:
             features: A pyramids ``FeatureCollection`` of polygon geometries; reprojected through
                 pyramids when needed.
-            column: The numeric column driving the fill colour (required).
-            cmap: Colormap name.
-            clim: Optional ``(vmin, vmax)`` colour limits; ``None`` auto-scales.
+            column: The column driving the fill colour (required); numeric for the continuous ramp, or any
+                hashable value for ``scheme="categorical"``.
+            scheme: ``"categorical"`` for distinct-value colouring; ``None`` (default) for a continuous ramp.
+            cmap: Colormap name (a qualitative map such as ``"tab10"`` is used for the categorical scheme when
+                left at the default).
+            clim: Optional ``(vmin, vmax)`` colour limits for the continuous ramp; ``None`` auto-scales.
             **opts: Extra HoloViews style options applied to the element.
 
         Returns:
@@ -276,6 +310,8 @@ class VectorMixin:
             raise KeyError(
                 f"choropleth column {column!r} not found in the feature attributes"
             )
+        if isinstance(scheme, str) and scheme.lower() == "categorical":
+            return self._categorical_polygons(features, column, cmap=cmap, **opts)
         if clim is not None:
             opts = {"clim": clim, **opts}
         return self.polygons(features, column=column, cmap=cmap, **opts)

--- a/src/digitalearth/interactive/vector.py
+++ b/src/digitalearth/interactive/vector.py
@@ -238,9 +238,12 @@ class VectorMixin:
         """Fill polygons by a distinct-value attribute, one colour per category (DC.8).
 
         The categorical counterpart of the continuous :meth:`polygons` path: each distinct value of ``column``
-        gets a colour from :func:`digitalearth._symbology.categorical_colors`, passed to GeoViews as a list
-        ``cmap`` over the categorical column (no continuous colorbar). The categories are recorded on
-        ``last_breaks`` for legend parity with the web tier.
+        gets a colour from :func:`digitalearth._symbology.categorical_colors`. The colour column is cast to
+        **string** and the colours are handed to GeoViews as a ``{label: colour}`` dict ``cmap`` — a numeric
+        column would otherwise be treated as a continuous dimension and the palette interpolated, so this is
+        what guarantees one discrete colour per distinct value (no continuous colorbar). The categories
+        (original values, in classifier order) are recorded on ``last_breaks`` for legend parity with the web
+        tier.
 
         Args:
             features: A pyramids ``FeatureCollection`` of polygons (reprojected through pyramids).
@@ -251,12 +254,17 @@ class VectorMixin:
         Returns:
             This map (chainable).
         """
-        from digitalearth._symbology import categorical_colors
+        from digitalearth._symbology import categorical_colors, resolve_categorical_cmap
 
         gdf = self._display_gdf(features)
-        categories, colors = categorical_colors(gdf[column], "tab10" if cmap == "viridis" else cmap)
+        categories, colors = categorical_colors(gdf[column], resolve_categorical_cmap(cmap))
+        # Render the column as discrete labels and map each label to its colour, so Bokeh colours it
+        # categorically (a numeric column would map continuously and interpolate the palette).
+        gdf = gdf.copy()
+        gdf[column] = gdf[column].astype(str)
+        cmap_by_label = {str(category): color for category, color in zip(categories, colors)}
         element = self._vector_element("Polygons", gdf, vdims=[column])
-        common = {"color": column, "cmap": colors, "colorbar": False, **opts}
+        common = {"color": column, "cmap": cmap_by_label, "colorbar": False, **opts}
         element = self._styled(element, common=common, bokeh={"tools": ["hover"]})
         self.last_breaks = list(categories)
         return self.add_element(element)
@@ -312,6 +320,8 @@ class VectorMixin:
             )
         if isinstance(scheme, str) and scheme.lower() == "categorical":
             return self._categorical_polygons(features, column, cmap=cmap, **opts)
+        # Continuous ramp: no discrete breaks — clear any recorded from a prior categorical call.
+        self.last_breaks = None
         if clim is not None:
             opts = {"clim": clim, **opts}
         return self.polygons(features, column=column, cmap=cmap, **opts)

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -410,6 +410,13 @@ class VectorMixin:
 
                 ```
         """
+        if str(opts.get("scheme", "")).lower() == "categorical":
+            raise NotImplementedError(
+                "scheme='categorical' is not supported in the static tier: cleopatra's PolygonGlyph colours "
+                "by a continuous/graduated scale only (no per-distinct-value mapping) — tracked as an upstream "
+                "cleopatra gap. Use WebMap.choropleth(..., scheme='categorical') or the interactive tier; "
+                "graduated schemes (quantiles/fisher_jenks/…) work here."
+            )
         gdf = self._vector_input(features, geom_types=("Polygon", "MultiPolygon"), name="choropleth",
                                  geom_label="polygon")
         polygons, repeats = self._polygon_vertices(gdf.geometry)

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -390,6 +390,10 @@ class VectorMixin:
             column: Name of the numeric column whose values colour the polygons.
             **opts: Styling kwargs forwarded to ``PolygonGlyph``. Pass ``scheme`` (e.g. ``"quantiles"`` /
                 ``"fisher_jenks"``) + ``k`` to colour by discrete classes instead of a continuous scale.
+                Note the default ``scheme`` differs by tier: this static tier (like the interactive
+                ``choropleth``) defaults to a **continuous** scale, whereas the **web** ``choropleth`` is
+                graduated-by-default (``"quantiles"``). Pass ``scheme`` explicitly for identical classification
+                across tiers.
 
         Returns:
             The ``PolyCollection`` (registered as a Scene layer).

--- a/src/digitalearth/web/decoration.py
+++ b/src/digitalearth/web/decoration.py
@@ -36,6 +36,14 @@ _BASEMAP_PROVIDERS = {
     ),
 }
 
+#: Canonical (correctly-cased) display names for the basemap keys, used in the not-found error message.
+_BASEMAP_DISPLAY_NAMES = {
+    "cartodark": "CartoDark",
+    "cartolight": "CartoLight",
+    "cartovoyager": "CartoVoyager",
+    "osm": "OSM",
+}
+
 #: The four legal MapLibre control corners.
 _CONTROL_POSITIONS = ("top-left", "top-right", "bottom-left", "bottom-right")
 
@@ -118,7 +126,7 @@ class DecorationMixin:
         if key not in _BASEMAP_PROVIDERS:
             raise ValueError(
                 f"unknown basemap provider {provider!r}; choose one of "
-                f"{sorted(p.capitalize() for p in _BASEMAP_PROVIDERS)} or pass a tile URL to tiles()"
+                f"{sorted(_BASEMAP_DISPLAY_NAMES.values())} or pass a tile URL to tiles()"
             )
         url, attribution = _BASEMAP_PROVIDERS[key]
         return self.tiles(url, attribution=attribution, opacity=opacity)
@@ -259,11 +267,10 @@ class DecorationMixin:
                 four legal MapLibre corners.
         """
         _require_maplibre()
-        _check_position(position)
-        from maplibre.plugins import MapboxDrawControls, MapboxDrawOptions
-
         if not (distance or area):
             raise ValueError("measure() needs distance and/or area enabled")
+        _check_position(position)
+        from maplibre.plugins import MapboxDrawControls, MapboxDrawOptions
         options = MapboxDrawOptions(
             display_controls_default=False,
             controls=MapboxDrawControls(line_string=distance, polygon=area, trash=True),

--- a/src/digitalearth/web/decoration.py
+++ b/src/digitalearth/web/decoration.py
@@ -141,6 +141,9 @@ class DecorationMixin:
 
         Returns:
             This map (chainable).
+
+        Raises:
+            ValueError: when ``position`` is not one of the four legal MapLibre corners.
         """
         _require_maplibre()
         _check_position(position)
@@ -167,6 +170,9 @@ class DecorationMixin:
 
         Returns:
             This map (chainable).
+
+        Raises:
+            ValueError: when ``position`` is not one of the four legal MapLibre corners.
         """
         _require_maplibre()
         _check_position(position)
@@ -187,6 +193,9 @@ class DecorationMixin:
 
         Returns:
             This map (chainable).
+
+        Raises:
+            ValueError: when ``position`` is not one of the four legal MapLibre corners.
         """
         _require_maplibre()
         _check_position(position)
@@ -246,7 +255,8 @@ class DecorationMixin:
             This map (chainable).
 
         Raises:
-            ValueError: if neither ``distance`` nor ``area`` is enabled.
+            ValueError: if neither ``distance`` nor ``area`` is enabled, or if ``position`` is not one of the
+                four legal MapLibre corners.
         """
         _require_maplibre()
         _check_position(position)

--- a/src/digitalearth/web/decoration.py
+++ b/src/digitalearth/web/decoration.py
@@ -208,8 +208,10 @@ class DecorationMixin:
     ) -> "DecorationMixin":
         """Add a draw-based measure tool — draw a line (distance) or polygon (area) to measure (ED.10).
 
-        Enables MapLibre's draw control scoped to line and/or polygon geometries, so the user draws the shape
-        to measure. The drawn GeoJSON is available on the rendered widget
+        Note this adds a **drawing** control, not a live on-map readout: it does not display the distance/area
+        number on the map (that GIS computation is left to pyramids, below). It enables MapLibre's draw control
+        scoped to line and/or polygon geometries, so the user draws the shape to measure. The drawn GeoJSON is
+        available on the rendered widget
         (``draw_feature_collection_all`` and the ``draw_features_created``/``…_updated`` events). Computing the
         numeric distance/area from that geometry is a **GIS** operation — do it in pyramids (geodesic length /
         area), keeping this tier to the (visualization) drawing control.

--- a/src/digitalearth/web/decoration.py
+++ b/src/digitalearth/web/decoration.py
@@ -12,7 +12,7 @@ custom HTML control, a DW.6 export concern). ``choropleth`` still exposes its cl
 
 from typing import Any, List, Optional
 
-from digitalearth.web.base import _require_layer_api
+from digitalearth.web.base import _require_layer_api, _require_maplibre
 
 #: Named raster XYZ basemaps → ``(url_template, attribution)``. All are token-free public tile services.
 _BASEMAP_PROVIDERS = {
@@ -102,6 +102,104 @@ class DecorationMixin:
             )
         url, attribution = _BASEMAP_PROVIDERS[key]
         return self.tiles(url, attribution=attribution, opacity=opacity)
+
+    def navigation(
+        self,
+        *,
+        position: str = "top-right",
+        show_compass: bool = True,
+        show_zoom: bool = True,
+        visualize_pitch: bool = False,
+    ) -> "DecorationMixin":
+        """Add MapLibre navigation controls — zoom buttons and a compass (ED.13).
+
+        Args:
+            position: Corner placement (``"top-right"``/``"top-left"``/``"bottom-right"``/``"bottom-left"``).
+            show_compass: Show the compass / bearing-reset button.
+            show_zoom: Show the zoom in/out buttons.
+            visualize_pitch: Show the map pitch on the compass.
+
+        Returns:
+            This map (chainable).
+        """
+        _require_maplibre()
+        from maplibre.controls import NavigationControl
+
+        control = NavigationControl(
+            show_compass=show_compass, show_zoom=show_zoom, visualize_pitch=visualize_pitch
+        )
+
+        def apply(widget: Any) -> None:
+            widget.add_control(control, position)
+
+        return self.add_layer(layer=apply)
+
+    def scale_bar(
+        self, *, position: str = "bottom-left", unit: str = "metric", max_width: int = 100
+    ) -> "DecorationMixin":
+        """Add a MapLibre scale bar (ED.13).
+
+        Args:
+            position: Corner placement for the scale bar.
+            unit: ``"metric"``, ``"imperial"`` or ``"nautical"``.
+            max_width: Maximum scale-bar width in pixels.
+
+        Returns:
+            This map (chainable).
+        """
+        _require_maplibre()
+        from maplibre.controls import ScaleControl
+
+        control = ScaleControl(unit=unit, max_width=int(max_width))
+
+        def apply(widget: Any) -> None:
+            widget.add_control(control, position)
+
+        return self.add_layer(layer=apply)
+
+    def fullscreen(self, *, position: str = "top-right") -> "DecorationMixin":
+        """Add a MapLibre fullscreen toggle control (ED.13).
+
+        Args:
+            position: Corner placement for the fullscreen button.
+
+        Returns:
+            This map (chainable).
+        """
+        _require_maplibre()
+        from maplibre.controls import FullscreenControl
+
+        control = FullscreenControl()
+
+        def apply(widget: Any) -> None:
+            widget.add_control(control, position)
+
+        return self.add_layer(layer=apply)
+
+    def controls(
+        self, *, navigation: bool = True, scale: bool = True, fullscreen: bool = False
+    ) -> "DecorationMixin":
+        """Add the common navigation / scale / fullscreen controls in one call (ED.13).
+
+        A convenience over :meth:`navigation`, :meth:`scale_bar` and :meth:`fullscreen`. Note: py-maplibregl
+        has no built-in **minimap** control, so a minimap is not offered here (it would need a custom JS
+        control — tracked as a follow-up).
+
+        Args:
+            navigation: Add zoom + compass controls.
+            scale: Add a scale bar.
+            fullscreen: Add a fullscreen toggle.
+
+        Returns:
+            This map (chainable).
+        """
+        if navigation:
+            self.navigation()
+        if scale:
+            self.scale_bar()
+        if fullscreen:
+            self.fullscreen()
+        return self
 
     @staticmethod
     def _attribute_template(fields: Optional[List[str]]) -> dict:

--- a/src/digitalearth/web/decoration.py
+++ b/src/digitalearth/web/decoration.py
@@ -36,6 +36,24 @@ _BASEMAP_PROVIDERS = {
     ),
 }
 
+#: The four legal MapLibre control corners.
+_CONTROL_POSITIONS = ("top-left", "top-right", "bottom-left", "bottom-right")
+
+
+def _check_position(position: str) -> None:
+    """Validate a control corner, raising ``ValueError`` for anything but the four legal MapLibre corners.
+
+    Args:
+        position: The requested corner placement.
+
+    Raises:
+        ValueError: when ``position`` is not one of ``top-left``/``top-right``/``bottom-left``/``bottom-right``.
+    """
+    if position not in _CONTROL_POSITIONS:
+        raise ValueError(
+            f"unknown control position {position!r}; choose one of {list(_CONTROL_POSITIONS)}"
+        )
+
 
 class DecorationMixin:
     """Basemap/tiles and popup/tooltip builders for :class:`~digitalearth.web.map.WebMap`."""
@@ -125,6 +143,7 @@ class DecorationMixin:
             This map (chainable).
         """
         _require_maplibre()
+        _check_position(position)
         from maplibre.controls import NavigationControl
 
         control = NavigationControl(
@@ -150,6 +169,7 @@ class DecorationMixin:
             This map (chainable).
         """
         _require_maplibre()
+        _check_position(position)
         from maplibre.controls import ScaleControl
 
         control = ScaleControl(unit=unit, max_width=int(max_width))
@@ -169,6 +189,7 @@ class DecorationMixin:
             This map (chainable).
         """
         _require_maplibre()
+        _check_position(position)
         from maplibre.controls import FullscreenControl
 
         control = FullscreenControl()
@@ -228,6 +249,7 @@ class DecorationMixin:
             ValueError: if neither ``distance`` nor ``area`` is enabled.
         """
         _require_maplibre()
+        _check_position(position)
         from maplibre.plugins import MapboxDrawControls, MapboxDrawOptions
 
         if not (distance or area):

--- a/src/digitalearth/web/decoration.py
+++ b/src/digitalearth/web/decoration.py
@@ -1,13 +1,15 @@
-"""DecorationMixin — web-tier basemaps/tiles (DW.1a) and popups/tooltips (DW.2).
+"""DecorationMixin — web-tier basemaps/tiles, popups/tooltips, and map controls.
 
-Adds raster XYZ basemaps beneath the data (``basemap``/``tiles``) and hover/click attribute readouts
-(``tooltip``/``popup``) on top of a data layer. Each builder registers a callable on the map's layer
-registry (basemaps as an underlay; popups/tooltips as post-layer ``add_popup``/``add_tooltip`` calls).
+Adds raster XYZ basemaps beneath the data (``basemap``/``tiles``, DW.1a), hover/click attribute readouts
+(``tooltip``/``popup``, DW.2), MapLibre UI controls (``navigation``/``scale_bar``/``fullscreen``/``controls``,
+ED.13) and a draw-based ``measure`` tool (ED.10). Each builder registers a callable on the map's layer
+registry (basemaps as an underlay; popups/tooltips/controls as post-render ``add_*`` calls).
 
 Out of scope here (deferred): ``pmtiles`` (needs the optional ``pmtiles`` reader, intentionally not in the
-``[web]`` extra) and an on-map ``legend`` control (py-maplibregl has no built-in legend widget — it needs a
-custom HTML control, a DW.6 export concern). ``choropleth`` still exposes its class breaks via
-``WebMap.last_breaks`` so a caller can build a legend out-of-band.
+``[web]`` extra); an on-map ``legend`` control and a **minimap** (py-maplibregl has neither built in — both
+need a custom HTML/JS control). ``choropleth`` still exposes its class breaks via ``WebMap.last_breaks`` so a
+caller can build a legend out-of-band; the ``measure`` tool exposes the drawn geometry for pyramids to compute
+geodesic distance/area (the GIS part).
 """
 
 from typing import Any, List, Optional
@@ -200,6 +202,43 @@ class DecorationMixin:
         if fullscreen:
             self.fullscreen()
         return self
+
+    def measure(
+        self, *, distance: bool = True, area: bool = True, position: str = "top-left"
+    ) -> "DecorationMixin":
+        """Add a draw-based measure tool — draw a line (distance) or polygon (area) to measure (ED.10).
+
+        Enables MapLibre's draw control scoped to line and/or polygon geometries, so the user draws the shape
+        to measure. The drawn GeoJSON is available on the rendered widget
+        (``draw_feature_collection_all`` and the ``draw_features_created``/``…_updated`` events). Computing the
+        numeric distance/area from that geometry is a **GIS** operation — do it in pyramids (geodesic length /
+        area), keeping this tier to the (visualization) drawing control.
+
+        Args:
+            distance: Offer the line tool (measure distance along a path).
+            area: Offer the polygon tool (measure enclosed area).
+            position: Corner placement for the draw toolbar.
+
+        Returns:
+            This map (chainable).
+
+        Raises:
+            ValueError: if neither ``distance`` nor ``area`` is enabled.
+        """
+        _require_maplibre()
+        from maplibre.plugins import MapboxDrawControls, MapboxDrawOptions
+
+        if not (distance or area):
+            raise ValueError("measure() needs distance and/or area enabled")
+        options = MapboxDrawOptions(
+            display_controls_default=False,
+            controls=MapboxDrawControls(line_string=distance, polygon=area, trash=True),
+        )
+
+        def apply(widget: Any) -> None:
+            widget.add_mapbox_draw(options, position)
+
+        return self.add_layer(layer=apply)
 
     @staticmethod
     def _attribute_template(fields: Optional[List[str]]) -> dict:

--- a/src/digitalearth/web/vector.py
+++ b/src/digitalearth/web/vector.py
@@ -61,9 +61,9 @@ class VectorMixin:
             return value
 
         if isinstance(scheme, str) and scheme.lower() == "categorical":
-            from digitalearth._symbology import categorical_colors
+            from digitalearth._symbology import categorical_colors, resolve_categorical_cmap
 
-            categories, colors = categorical_colors(values, "tab10" if cmap == "viridis" else cmap)
+            categories, colors = categorical_colors(values, resolve_categorical_cmap(cmap))
             expr = ["match", ["get", column]]
             for category, color in zip(categories, colors):
                 expr.extend([_native(category), color])

--- a/src/digitalearth/web/vector.py
+++ b/src/digitalearth/web/vector.py
@@ -53,11 +53,23 @@ class VectorMixin:
         import numpy as np
 
         def _native(value: Any) -> Any:
-            """Coerce a numpy scalar to a JSON-native ``int``/``float``/``str`` for a MapLibre literal."""
+            """Coerce a category to a JSON-native, MapLibre-legal ``match`` label.
+
+            MapLibre rejects non-integer numeric ``match`` labels ("Numeric branch labels must be integer
+            values"), so a whole-valued float (integer class codes stored as ``float64`` — the common shape
+            for codes read from GeoJSON) is narrowed to ``int``; a genuinely non-integral float cannot key a
+            ``match`` and is rejected with a clear error. Integers and strings pass through unchanged.
+            """
             if isinstance(value, np.integer):
                 return int(value)
-            if isinstance(value, np.floating):
-                return float(value)
+            if isinstance(value, (np.floating, float)):
+                as_float = float(value)
+                if not as_float.is_integer():
+                    raise ValueError(
+                        f"categorical column {column!r} has a non-integer category {as_float!r}; a "
+                        f"categorical scheme needs discrete integer codes or string labels"
+                    )
+                return int(as_float)
             return value
 
         if isinstance(scheme, str) and scheme.lower() == "categorical":

--- a/src/digitalearth/web/vector.py
+++ b/src/digitalearth/web/vector.py
@@ -36,18 +36,40 @@ class VectorMixin:
             values: The 1-D value array driving the colour (used to compute breaks / limits).
             column: The GeoJSON property name the expression reads with ``["get", column]``.
             scheme: A cleopatra classification scheme (``"quantiles"``/``"fisher_jenks"``/… or an explicit
-                edge sequence) for a graduated ``step`` expression; ``None`` for a continuous ramp.
+                edge sequence) for a graduated ``step`` expression; ``"categorical"`` for a distinct-value
+                ``match`` expression (DC.8); ``None`` for a continuous ramp.
             k: Number of classes for the graduated schemes.
-            cmap: matplotlib colormap name sampled for the class / ramp colours.
+            cmap: matplotlib colormap name sampled for the class / ramp colours (a qualitative map such as
+                ``"tab10"`` is used for ``scheme="categorical"`` when ``cmap`` is left at the default).
 
         Returns:
-            A MapLibre expression list (``["step", …]`` or ``["interpolate", …]``). Also sets
-            ``self.last_breaks`` to the breaks (graduated edges) or ramp stops.
+            A MapLibre expression list (``["step", …]``, ``["match", …]`` or ``["interpolate", …]``). Also
+            sets ``self.last_breaks`` to the breaks (graduated edges), the categories, or the ramp stops.
 
         Raises:
-            ValueError: propagated from ``cleopatra.styles.classify`` (unknown scheme, no spread, …).
+            ValueError: propagated from ``cleopatra.styles.classify`` (unknown scheme, no spread, …) or from
+                the categorical helper (no non-null values).
         """
         import numpy as np
+
+        def _native(value: Any) -> Any:
+            """Coerce a numpy scalar to a JSON-native ``int``/``float``/``str`` for a MapLibre literal."""
+            if isinstance(value, np.integer):
+                return int(value)
+            if isinstance(value, np.floating):
+                return float(value)
+            return value
+
+        if isinstance(scheme, str) and scheme.lower() == "categorical":
+            from digitalearth._symbology import categorical_colors
+
+            categories, colors = categorical_colors(values, "tab10" if cmap == "viridis" else cmap)
+            expr = ["match", ["get", column]]
+            for category, color in zip(categories, colors):
+                expr.extend([_native(category), color])
+            expr.append("#cccccc")  # fallback colour for values outside the known categories
+            self.last_breaks = [_native(c) for c in categories]
+            return expr
 
         if scheme is not None:
             from cleopatra.styles import classify
@@ -273,14 +295,17 @@ class VectorMixin:
 
         Graduated by default (``scheme="quantiles"``): the class breaks come from
         ``cleopatra.styles.classify`` and are compiled into a MapLibre ``step`` paint expression, so the
-        classes match the static tier's ``choropleth``. Pass ``scheme=None`` for a continuous ramp. The
-        breaks are exposed on ``WebMap.last_breaks`` for building a legend.
+        classes match the static tier's ``choropleth``. Pass ``scheme="categorical"`` to colour an unordered
+        attribute by distinct value (a MapLibre ``match`` expression, DC.8), or ``scheme=None`` for a
+        continuous ramp. The breaks / categories are exposed on ``WebMap.last_breaks`` for building a legend.
 
         Args:
             features: A pyramids polygon ``FeatureCollection`` / GeoDataFrame.
-            column: The numeric attribute that colours the polygons (required).
+            column: The attribute that colours the polygons (numeric for graduated/continuous; any hashable
+                value for ``scheme="categorical"``). Required.
             scheme: A cleopatra classification scheme (``"quantiles"``, ``"equal_interval"``,
-                ``"fisher_jenks"``, …) or an explicit edge sequence; ``None`` for a continuous ramp.
+                ``"fisher_jenks"``, …) or an explicit edge sequence for graduated colouring;
+                ``"categorical"`` for distinct-value colouring; ``None`` for a continuous ramp.
             k: Number of classes for the graduated schemes.
             cmap: matplotlib colormap name.
             opacity: Fill opacity in ``[0, 1]``.

--- a/src/digitalearth/web/vector.py
+++ b/src/digitalearth/web/vector.py
@@ -306,10 +306,14 @@ class VectorMixin:
         """Draw a thematic polygon choropleth coloured by ``column`` (recipe W2).
 
         Graduated by default (``scheme="quantiles"``): the class breaks come from
-        ``cleopatra.styles.classify`` and are compiled into a MapLibre ``step`` paint expression, so the
-        classes match the static tier's ``choropleth``. Pass ``scheme="categorical"`` to colour an unordered
-        attribute by distinct value (a MapLibre ``match`` expression, DC.8), or ``scheme=None`` for a
-        continuous ramp. The breaks / categories are exposed on ``WebMap.last_breaks`` for building a legend.
+        ``cleopatra.styles.classify`` and are compiled into a MapLibre ``step`` paint expression. Pass
+        ``scheme="categorical"`` to colour an unordered attribute by distinct value (a MapLibre ``match``
+        expression, DC.8), or ``scheme=None`` for a continuous ramp. The breaks / categories are exposed on
+        ``WebMap.last_breaks`` for building a legend.
+
+        Note the default ``scheme`` differs by tier: this **web** tier is graduated-by-default
+        (``"quantiles"``), whereas the interactive and static ``choropleth`` default to a **continuous** ramp.
+        Pass ``scheme`` explicitly for identical classification across tiers.
 
         Args:
             features: A pyramids polygon ``FeatureCollection`` / GeoDataFrame.

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -190,6 +190,12 @@ class TestAggregateByCategory:
         with pytest.raises(TypeError, match="cannot aggregate column 'cat'"):
             charts.line_by(gdf, "year", "cat", agg="sum")
 
+    def test_non_numeric_reducing_agg_raises_clear_error(self, gdf):
+        """mean/median/std on a non-numeric column also surface the clear message, not a raw pandas error (L1)."""
+        for agg in ("mean", "median", "std"):
+            with pytest.raises(TypeError, match="cannot aggregate column 'cat'"):
+                charts.bar_by(gdf, "year", "cat", agg=agg)
+
     def test_exported_top_level(self):
         import digitalearth
 

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -94,6 +94,11 @@ class TestHistogram:
         fig, ax, hist = charts.histogram([1, 1, 2, 3, 3, 3], bins=3)
         assert len(ax.patches) == 3, f"expected 3 bins, got {len(ax.patches)}"
 
+    def test_raw_array_drops_nonfinite(self):
+        """A raw 1-D array with NaN/inf histograms cleanly instead of an opaque numpy range error (M1)."""
+        fig, ax, hist = charts.histogram([1.0, np.nan, 3.0, np.inf, 2.0], bins=3)
+        assert len(ax.patches) == 3, f"expected 3 bins over the finite values, got {len(ax.patches)}"
+
     def test_dataset_input_drops_nodata(self):
         """A pyramids Dataset is histogrammed over its first band with nodata excluded."""
         from pyramids.dataset import Dataset

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -262,6 +262,11 @@ class TestStatistics:
         s = charts.statistics(range(1001), quantiles=(0.5, 0.505))
         assert "q50" in s and "q50.5" in s, f"fractional quantiles must not collide: {sorted(s)}"
 
+    def test_colliding_quantile_keys_raise(self):
+        """Two quantiles that format to the same key raise instead of silently overwriting (N2)."""
+        with pytest.raises(ValueError, match="collide on key"):
+            charts.statistics(range(101), quantiles=(0.5, 0.5000001))
+
     def test_drops_nonfinite(self):
         """NaN/inf are excluded from the summary."""
         s = charts.statistics([1.0, np.nan, 3.0, np.inf])

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -178,6 +178,13 @@ class TestAggregateByCategory:
         with pytest.raises(TypeError, match="groupby"):
             charts.bar_by([1, 2, 3], "cat")
 
+    def test_non_numeric_value_column_raises_clear_error(self, gdf):
+        """Aggregating a non-numeric value column surfaces a clear message naming column + agg (L2)."""
+        with pytest.raises(TypeError, match="cannot aggregate column 'cat'"):
+            charts.bar_by(gdf, "year", "cat", agg="sum")
+        with pytest.raises(TypeError, match="cannot aggregate column 'cat'"):
+            charts.line_by(gdf, "year", "cat", agg="sum")
+
     def test_exported_top_level(self):
         import digitalearth
 
@@ -249,6 +256,11 @@ class TestStatistics:
         s = charts.statistics(range(101), quantiles=(0.1, 0.9))
         assert s["q10"] == 10.0 and s["q90"] == 90.0
         assert "q50" not in s, "only the requested quantiles should be present"
+
+    def test_fractional_quantiles_get_distinct_keys(self):
+        """Near-equal quantiles map to distinct keys instead of colliding on one (N2)."""
+        s = charts.statistics(range(1001), quantiles=(0.5, 0.505))
+        assert "q50" in s and "q50.5" in s, f"fractional quantiles must not collide: {sorted(s)}"
 
     def test_drops_nonfinite(self):
         """NaN/inf are excluded from the summary."""

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -141,6 +141,55 @@ class TestHistogram:
         assert sorted(out.tolist()) == [1.0, 2.0, 3.0, 4.0], f"all cells should be kept, got {out}"
 
 
+class TestScatter:
+    """Tests for charts.scatter (DC.3) and the _column_or_array helper."""
+
+    def test_arrays_draw_one_collection(self):
+        """Two arrays draw a single scatter PathCollection and return the Axes."""
+        ax = charts.scatter([1, 2, 3], [4, 5, 6])
+        assert isinstance(ax, Axes), f"expected an Axes, got {type(ax)}"
+        assert len(ax.collections) == 1, f"expected one scatter collection, got {len(ax.collections)}"
+
+    def test_field_vs_field_by_column(self):
+        """With a GeoDataFrame, x/y resolve to column names (DC.3)."""
+        gpd = pytest.importorskip("geopandas")
+        from shapely.geometry import Point
+
+        gdf = gpd.GeoDataFrame(
+            {"a": [1.0, 2.0, 3.0], "b": [3.0, 2.0, 1.0]},
+            geometry=[Point(i, i) for i in range(3)],
+            crs=4326,
+        )
+        ax = charts.scatter("a", "b", data=gdf)
+        assert len(ax.collections) == 1
+
+    def test_color_by_column_adds_colorbar(self):
+        """Colouring by a value column maps point colour (and adds a colorbar)."""
+        gpd = pytest.importorskip("geopandas")
+        from shapely.geometry import Point
+
+        gdf = gpd.GeoDataFrame(
+            {"a": [1.0, 2.0, 3.0], "b": [3.0, 2.0, 1.0], "v": [0.1, 0.5, 0.9]},
+            geometry=[Point(i, i) for i in range(3)],
+            crs=4326,
+        )
+        ax = charts.scatter("a", "b", data=gdf, color_by="v")
+        assert ax.collections, "coloured scatter should still draw a collection"
+
+    def test_missing_column_raises(self):
+        gpd = pytest.importorskip("geopandas")
+        from shapely.geometry import Point
+
+        gdf = gpd.GeoDataFrame({"a": [1.0]}, geometry=[Point(0, 0)], crs=4326)
+        with pytest.raises(KeyError, match="nope"):
+            charts.scatter("a", "nope", data=gdf)
+
+    def test_exported_top_level(self):
+        import digitalearth
+
+        assert digitalearth.scatter is charts.scatter and "scatter" in digitalearth.__all__
+
+
 class TestStatistics:
     """Tests for charts.statistics (DC.5) and the _field_values helper."""
 

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -105,6 +105,19 @@ class TestHistogram:
         fig, ax, hist = charts.histogram(ds, bins=3)
         assert len(ax.patches) == 3
 
+    def test_geodataframe_column(self):
+        """A GeoDataFrame column is histogrammed in one call via `column=` (DC.1)."""
+        gpd = pytest.importorskip("geopandas")
+        from shapely.geometry import Point
+
+        gdf = gpd.GeoDataFrame(
+            {"pop": [1.0, 1.0, 2.0, 3.0, 3.0, 3.0]},
+            geometry=[Point(i, i) for i in range(6)],
+            crs=4326,
+        )
+        fig, ax, hist = charts.histogram(gdf, column="pop", bins=3)
+        assert len(ax.patches) == 3, f"expected 3 bins, got {len(ax.patches)}"
+
     def test_2d_values_overlaid(self):
         """A 2-D array draws an overlaid histogram per column (one colour per series, as cleopatra needs)."""
         vals = np.column_stack([[1, 2, 3, 4], [2, 3, 4, 5]])

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -141,6 +141,50 @@ class TestHistogram:
         assert sorted(out.tolist()) == [1.0, 2.0, 3.0, 4.0], f"all cells should be kept, got {out}"
 
 
+class TestAggregateByCategory:
+    """Tests for charts.bar_by / line_by (DC.4) and the _grouped_series helper."""
+
+    @pytest.fixture()
+    def gdf(self):
+        gpd = pytest.importorskip("geopandas")
+        from shapely.geometry import Point
+
+        return gpd.GeoDataFrame(
+            {"cat": ["a", "a", "b", "c"], "year": [2000, 2000, 2010, 2010], "v": [1.0, 2.0, 3.0, 4.0]},
+            geometry=[Point(i, i) for i in range(4)],
+            crs=4326,
+        )
+
+    def test_bar_by_sum(self, gdf):
+        """bar_by sums a value column per category, one bar per category in sorted-key order."""
+        ax = charts.bar_by(gdf, "cat", "v", agg="sum")
+        heights = [round(rect.get_height(), 1) for rect in ax.containers[0]]
+        assert heights == [3.0, 3.0, 4.0], f"a=1+2, b=3, c=4 expected, got {heights}"
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["a", "b", "c"]
+
+    def test_bar_by_count_without_column(self, gdf):
+        """With no value column, bar_by counts rows per category."""
+        ax = charts.bar_by(gdf, "cat")
+        assert [int(r.get_height()) for r in ax.containers[0]] == [2, 1, 1]
+
+    def test_line_by_mean_by_time(self, gdf):
+        """line_by aggregates by an ordered/time key and draws one line."""
+        ax = charts.line_by(gdf, "year", "v", agg="mean")
+        assert len(ax.lines) == 1
+        ys = list(ax.lines[0].get_ydata())
+        assert ys == [1.5, 3.5], f"2000->mean(1,2)=1.5, 2010->mean(3,4)=3.5, got {ys}"
+
+    def test_non_dataframe_raises(self):
+        with pytest.raises(TypeError, match="groupby"):
+            charts.bar_by([1, 2, 3], "cat")
+
+    def test_exported_top_level(self):
+        import digitalearth
+
+        assert digitalearth.bar_by is charts.bar_by and "bar_by" in digitalearth.__all__
+        assert digitalearth.line_by is charts.line_by and "line_by" in digitalearth.__all__
+
+
 class TestScatter:
     """Tests for charts.scatter (DC.3) and the _column_or_array helper."""
 

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -128,6 +128,67 @@ class TestHistogram:
         assert sorted(out.tolist()) == [1.0, 2.0, 3.0, 4.0], f"all cells should be kept, got {out}"
 
 
+class TestStatistics:
+    """Tests for charts.statistics (DC.5) and the _field_values helper."""
+
+    def test_basic_summary(self):
+        """count/min/max/mean and the default quartiles are computed over the finite values."""
+        s = charts.statistics([1, 2, 3, 4])
+        assert (s["count"], s["min"], s["max"], s["mean"]) == (4, 1.0, 4.0, 2.5)
+        assert s["q50"] == 2.5, f"median should be q50=2.5, got {s.get('q50')}"
+        assert set(s) == {"count", "min", "max", "mean", "std", "q25", "q50", "q75"}
+
+    def test_custom_quantiles(self):
+        """Requested quantiles appear under q<pct> keys."""
+        s = charts.statistics(range(101), quantiles=(0.1, 0.9))
+        assert s["q10"] == 10.0 and s["q90"] == 90.0
+        assert "q50" not in s, "only the requested quantiles should be present"
+
+    def test_drops_nonfinite(self):
+        """NaN/inf are excluded from the summary."""
+        s = charts.statistics([1.0, np.nan, 3.0, np.inf])
+        assert s["count"] == 2 and s["mean"] == 2.0
+
+    def test_geodataframe_column(self):
+        """A GeoDataFrame column is summarised when `column` is given."""
+        gpd = pytest.importorskip("geopandas")
+        from shapely.geometry import Point
+
+        gdf = gpd.GeoDataFrame(
+            {"pop": [10.0, 20.0, 30.0]},
+            geometry=[Point(i, i) for i in range(3)],
+            crs=4326,
+        )
+        assert charts.statistics(gdf, column="pop")["mean"] == 20.0
+
+    def test_dataset_band(self):
+        """A pyramids Dataset is summarised over its first band, nodata dropped."""
+        from pyramids.dataset import Dataset
+
+        arr = np.array([[1.0, 2.0], [3.0, -9999.0]], dtype="float32")
+        ds = Dataset.create_from_array(arr=arr, geo=(0.0, 1.0, 0.0, 2.0, 0.0, -1.0), epsg=4326)
+        s = charts.statistics(ds)
+        assert s["count"] == 3 and s["min"] == 1.0 and s["max"] == 3.0
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="no finite values"):
+            charts.statistics([np.nan, np.inf])
+
+    def test_missing_column_raises(self):
+        gpd = pytest.importorskip("geopandas")
+        from shapely.geometry import Point
+
+        gdf = gpd.GeoDataFrame({"pop": [1.0]}, geometry=[Point(0, 0)], crs=4326)
+        with pytest.raises(KeyError, match="nope"):
+            charts.statistics(gdf, column="nope")
+
+    def test_exported_top_level(self):
+        import digitalearth
+
+        assert digitalearth.statistics is charts.statistics
+        assert "statistics" in digitalearth.__all__
+
+
 class TestFigOf:
     """Tests for the _fig_of helper."""
 

--- a/tests/test_interactive_charts.py
+++ b/tests/test_interactive_charts.py
@@ -1,0 +1,74 @@
+"""Tests for digitalearth.interactive.charts — HoloViz/Bokeh charts (DC.6).
+
+The lazy-import contract runs without the engine; the chart builders ``importorskip`` holoviews and run in the
+``interactive`` pixi env.
+"""
+import sys
+
+import pytest
+
+from digitalearth.interactive import charts as icharts
+
+
+class TestLazyImport:
+    """The module imports without holoviews; builders fail actionably without it."""
+
+    def test_module_imports_without_engine(self):
+        for name in ("histogram", "scatter", "bar", "line", "bar_by", "line_by"):
+            assert hasattr(icharts, name), f"interactive.charts.{name} should exist"
+
+    def test_missing_engine_raises_actionable_error(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "holoviews", None)  # makes `import holoviews` raise
+        with pytest.raises(ImportError, match=r"digitalearth\[interactive\]"):
+            icharts.histogram([1, 2, 3])
+
+
+class TestInteractiveCharts:
+    """The chart builders return the expected HoloViews elements (engine required)."""
+
+    @pytest.fixture(autouse=True)
+    def _need_engine(self):
+        pytest.importorskip("holoviews")
+
+    @pytest.fixture()
+    def gdf(self):
+        gpd = pytest.importorskip("geopandas")
+        from shapely.geometry import Point
+
+        return gpd.GeoDataFrame(
+            {"cat": ["a", "a", "b"], "year": [2000, 2000, 2010], "a_val": [1.0, 2.0, 3.0], "b_val": [3.0, 2.0, 1.0]},
+            geometry=[Point(i, i) for i in range(3)],
+            crs=4326,
+        )
+
+    def test_histogram(self):
+        import holoviews as hv
+
+        assert isinstance(icharts.histogram([1, 1, 2, 3, 3, 3], bins=3), hv.Histogram)
+
+    def test_histogram_by_column(self, gdf):
+        import holoviews as hv
+
+        assert isinstance(icharts.histogram(gdf, column="a_val", bins=3), hv.Histogram)
+
+    def test_scatter_arrays(self):
+        import holoviews as hv
+
+        assert isinstance(icharts.scatter([1, 2, 3], [4, 5, 6]), hv.Scatter)
+
+    def test_scatter_by_column(self, gdf):
+        import holoviews as hv
+
+        assert isinstance(icharts.scatter("a_val", "b_val", data=gdf), hv.Scatter)
+
+    def test_bar_and_line(self):
+        import holoviews as hv
+
+        assert isinstance(icharts.bar([0, 1, 2], [3, 1, 4]), hv.Bars)
+        assert isinstance(icharts.line([0, 1, 2], [0, 1, 4]), hv.Curve)
+
+    def test_bar_by_and_line_by(self, gdf):
+        import holoviews as hv
+
+        assert isinstance(icharts.bar_by(gdf, "cat", "a_val", agg="sum"), hv.Bars)
+        assert isinstance(icharts.line_by(gdf, "year", "a_val", agg="mean"), hv.Curve)

--- a/tests/test_interactive_charts.py
+++ b/tests/test_interactive_charts.py
@@ -5,6 +5,7 @@ The lazy-import contract runs without the engine; the chart builders ``importors
 """
 import sys
 
+import numpy as np
 import pytest
 
 from digitalearth.interactive import charts as icharts
@@ -50,6 +51,12 @@ class TestInteractiveCharts:
         import holoviews as hv
 
         assert isinstance(icharts.histogram(gdf, column="a_val", bins=3), hv.Histogram)
+
+    def test_histogram_raw_array_drops_nonfinite(self):
+        """A raw array with NaN/inf histograms cleanly instead of raising an opaque numpy range error (L2)."""
+        import holoviews as hv
+
+        assert isinstance(icharts.histogram([1.0, np.nan, 3.0, np.inf, 2.0], bins=3), hv.Histogram)
 
     def test_scatter_arrays(self):
         import holoviews as hv

--- a/tests/test_interactive_vector.py
+++ b/tests/test_interactive_vector.py
@@ -134,16 +134,26 @@ class TestPolygonsAndChoropleth:
         assert plot["clim"] == (0.0, 10.0), f"clim not honoured: {plot.get('clim')}"
 
     def test_choropleth_categorical_scheme(self, m, polygon_fc):
-        """scheme='categorical' colours by distinct value with a list cmap, recording the categories (DC.8)."""
+        """scheme='categorical' gives one *discrete* colour per distinct value, recording the categories (DC.8).
+
+        The colour column (``fid``, numeric) is rendered as discrete string labels with a ``{label: colour}``
+        dict cmap, so Bokeh colours it categorically rather than interpolating a continuous palette (M1).
+        """
         m.choropleth(polygon_fc, "fid", scheme="categorical")
         element = m.layers[0]
         assert isinstance(element, gv.Polygons)
         style = hv.Store.lookup_options("bokeh", element, "style").kwargs
         assert style["color"] == "fid"
-        assert isinstance(style["cmap"], list) and all(
-            isinstance(c, str) for c in style["cmap"]
-        ), f"categorical cmap should be a list of colours, got {style.get('cmap')!r}"
-        assert m.last_breaks is not None and len(m.last_breaks) >= 1, "categories should be recorded"
+        cmap = style["cmap"]
+        assert isinstance(cmap, dict), f"categorical cmap should be a label->colour dict, got {cmap!r}"
+        assert all(isinstance(c, str) and c.startswith("#") for c in cmap.values()), f"hex colours: {cmap}"
+        # one discrete colour per distinct value, and the labels are the (stringified) categories
+        n = len(m.last_breaks)
+        assert n >= 1, "categories should be recorded"
+        assert len(cmap) == n, f"expected {n} discrete colours, got {len(cmap)}"
+        assert set(cmap) == {str(c) for c in m.last_breaks}, "cmap keys must be the category labels"
+        # the rendered colour column is discrete (string), not the original numeric dtype
+        assert element.dimension_values("fid").dtype.kind in ("U", "O"), "colour column must be string-typed"
 
     def test_choropleth_missing_column_raises(self, m, polygon_fc):
         with pytest.raises(KeyError, match="nope"):

--- a/tests/test_interactive_vector.py
+++ b/tests/test_interactive_vector.py
@@ -167,6 +167,11 @@ class TestPolygonsAndChoropleth:
         assert cmap.get("n/a") == "#cccccc", f"missing values must map to the neutral fallback: {cmap}"
         assert {"a", "b"} <= set(cmap), f"real categories must still be coloured: {cmap}"
 
+    def test_choropleth_graduated_scheme_not_implemented(self, m, polygon_fc):
+        """A graduated scheme is rejected, not silently degraded to a continuous ramp (L1)."""
+        with pytest.raises(NotImplementedError, match="graduated scheme"):
+            m.choropleth(polygon_fc, "fid", scheme="quantiles")
+
     def test_choropleth_missing_column_raises(self, m, polygon_fc):
         with pytest.raises(KeyError, match="nope"):
             m.choropleth(polygon_fc, "nope")

--- a/tests/test_interactive_vector.py
+++ b/tests/test_interactive_vector.py
@@ -155,6 +155,18 @@ class TestPolygonsAndChoropleth:
         # the rendered colour column is discrete (string), not the original numeric dtype
         assert element.dimension_values("fid").dtype.kind in ("U", "O"), "colour column must be string-typed"
 
+    def test_choropleth_categorical_missing_values_get_fallback(self, m, polygon_fc):
+        """A NaN/None category gets the neutral '#cccccc' fallback in the dict cmap (web parity, L1)."""
+        fc = polygon_fc.copy()
+        n = len(fc)
+        kinds = [("a", "b")[i % 2] for i in range(n)]
+        kinds[0] = None
+        fc["kind"] = kinds
+        m.choropleth(fc, "kind", scheme="categorical")
+        cmap = hv.Store.lookup_options("bokeh", m.layers[0], "style").kwargs["cmap"]
+        assert cmap.get("n/a") == "#cccccc", f"missing values must map to the neutral fallback: {cmap}"
+        assert {"a", "b"} <= set(cmap), f"real categories must still be coloured: {cmap}"
+
     def test_choropleth_missing_column_raises(self, m, polygon_fc):
         with pytest.raises(KeyError, match="nope"):
             m.choropleth(polygon_fc, "nope")

--- a/tests/test_interactive_vector.py
+++ b/tests/test_interactive_vector.py
@@ -133,6 +133,18 @@ class TestPolygonsAndChoropleth:
         plot = hv.Store.lookup_options("bokeh", element, "plot").kwargs
         assert plot["clim"] == (0.0, 10.0), f"clim not honoured: {plot.get('clim')}"
 
+    def test_choropleth_categorical_scheme(self, m, polygon_fc):
+        """scheme='categorical' colours by distinct value with a list cmap, recording the categories (DC.8)."""
+        m.choropleth(polygon_fc, "fid", scheme="categorical")
+        element = m.layers[0]
+        assert isinstance(element, gv.Polygons)
+        style = hv.Store.lookup_options("bokeh", element, "style").kwargs
+        assert style["color"] == "fid"
+        assert isinstance(style["cmap"], list) and all(
+            isinstance(c, str) for c in style["cmap"]
+        ), f"categorical cmap should be a list of colours, got {style.get('cmap')!r}"
+        assert m.last_breaks is not None and len(m.last_breaks) >= 1, "categories should be recorded"
+
     def test_choropleth_missing_column_raises(self, m, polygon_fc):
         with pytest.raises(KeyError, match="nope"):
             m.choropleth(polygon_fc, "nope")

--- a/tests/test_interactive_vector.py
+++ b/tests/test_interactive_vector.py
@@ -167,6 +167,18 @@ class TestPolygonsAndChoropleth:
         assert cmap.get("n/a") == "#cccccc", f"missing values must map to the neutral fallback: {cmap}"
         assert {"a", "b"} <= set(cmap), f"real categories must still be coloured: {cmap}"
 
+    def test_choropleth_categorical_real_na_not_clobbered(self, m, polygon_fc):
+        """A genuine 'n/a' category keeps its colour; missing rows use a collision-free sentinel (L3)."""
+        fc = polygon_fc.copy()
+        n = len(fc)
+        kinds = [("n/a", "b")[i % 2] for i in range(n)]
+        kinds[0] = None
+        fc["kind"] = kinds
+        m.choropleth(fc, "kind", scheme="categorical")
+        cmap = hv.Store.lookup_options("bokeh", m.layers[0], "style").kwargs["cmap"]
+        assert cmap.get("n/a") not in (None, "#cccccc"), f"the real 'n/a' category must keep its colour: {cmap}"
+        assert cmap.get("n/a_") == "#cccccc", f"missing rows must use a distinct sentinel: {cmap}"
+
     def test_choropleth_graduated_scheme_not_implemented(self, m, polygon_fc):
         """A graduated scheme is rejected, not silently degraded to a continuous ramp (L1)."""
         with pytest.raises(NotImplementedError, match="graduated scheme"):

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -9,7 +9,7 @@ import digitalearth
 EXPECTED = [
     "quickplot", "quickmap", "Map", "Scene", "grid", "shared_colorbar", "projections",
     "get_source", "Source", "DimensionInfo",
-    "line", "bar", "histogram",
+    "line", "bar", "histogram", "scatter", "bar_by", "line_by", "statistics",
     "envelope", "quantile_band", "boxplot", "multiboxplot", "stripes",
     "TimeSeries", "Climatology",
     "Batch", "gallery", "load_plugins",

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -35,6 +35,12 @@ def test_choropleth_scheme_is_discrete(polygons):
     assert not isinstance(continuous.norm, BoundaryNorm)
 
 
+def test_choropleth_categorical_not_supported_in_static_tier(polygons):
+    """scheme='categorical' raises a clear, actionable error in the static tier (cleopatra gap, DC.8)."""
+    with pytest.raises(NotImplementedError, match="categorical"):
+        Map(crs=polygons.epsg).choropleth(polygons, column="fid", scheme="categorical")
+
+
 def test_voronoi_scheme_is_discrete(points_fc):
     """voronoi honours a categorical scheme on its filled cells."""
     pc = Map(crs=points_fc.epsg).voronoi(points_fc, column="fid", scheme="quantiles", k=3)

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 
-from digitalearth._symbology import categorical_colors
+from digitalearth._symbology import categorical_colors, resolve_categorical_cmap
 
 
 def test_distinct_categories_get_distinct_colors():
@@ -35,3 +35,9 @@ def test_unsortable_mixed_keeps_first_seen_order():
 def test_empty_raises():
     with pytest.raises(ValueError, match="no non-null"):
         categorical_colors([None, float("nan")])
+
+
+def test_resolve_categorical_cmap_swaps_continuous_default():
+    """The continuous default is swapped for a qualitative map; an explicit cmap is honoured (N1)."""
+    assert resolve_categorical_cmap("viridis") == "tab10", "continuous default → qualitative default"
+    assert resolve_categorical_cmap("Set2") == "Set2", "an explicit cmap must be honoured"

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -1,0 +1,37 @@
+"""Tests for digitalearth._symbology — categorical (distinct-value → colour) mapping (DC.8)."""
+import numpy as np
+import pytest
+
+from digitalearth._symbology import categorical_colors
+
+
+def test_distinct_categories_get_distinct_colors():
+    cats, colors = categorical_colors(["a", "b", "a", "c"])
+    assert cats == ["a", "b", "c"], f"categories should be sorted-unique, got {cats}"
+    assert len(colors) == 3 and all(c.startswith("#") for c in colors)
+    assert len(set(colors)) == 3, "each category should get a distinct colour"
+
+
+def test_colors_cycle_when_more_categories_than_cmap():
+    cats, colors = categorical_colors(list(range(12)), cmap="tab10")
+    assert len(cats) == 12 and len(colors) == 12, "colours must cycle, never run out"
+
+
+def test_drops_null_and_nan():
+    cats, _ = categorical_colors(["a", None, "b", float("nan")])
+    assert cats == ["a", "b"], f"None/NaN should be dropped, got {cats}"
+
+
+def test_numeric_categories_sorted():
+    cats, colors = categorical_colors([3, 1, 2, 1])
+    assert cats == [1, 2, 3] and len(colors) == 3
+
+
+def test_unsortable_mixed_keeps_first_seen_order():
+    cats, _ = categorical_colors(["b", 1, "a"])  # str vs int → not mutually comparable
+    assert set(cats) == {"b", 1, "a"} and len(cats) == 3
+
+
+def test_empty_raises():
+    with pytest.raises(ValueError, match="no non-null"):
+        categorical_colors([None, float("nan")])

--- a/tests/test_web_vector.py
+++ b/tests/test_web_vector.py
@@ -102,6 +102,19 @@ class TestColorExpr:
         literals = [expr[i] for i in range(2, len(expr) - 1, 2)]
         assert literals == [1, 2, 3] and all(type(v) is int for v in literals)
 
+    def test_categorical_whole_float_labels_narrow_to_int(self):
+        """Whole-valued float categories become int labels — MapLibre rejects non-integer match labels (M1)."""
+        m = WebMap()
+        expr = m._color_expr(np.array([1.0, 2.0, 1.0, 3.0]), "zone", "categorical", 5, "tab10")
+        literals = [expr[i] for i in range(2, len(expr) - 1, 2)]
+        assert literals == [1, 2, 3] and all(type(v) is int for v in literals), f"float cats must narrow: {literals}"
+        assert all(type(b) is int for b in m.last_breaks), f"recorded breaks must narrow too: {m.last_breaks}"
+
+    def test_categorical_non_integer_float_rejected(self):
+        """A non-integer float category cannot key a MapLibre match and is rejected clearly (M1)."""
+        with pytest.raises(ValueError, match="non-integer category"):
+            WebMap()._color_expr(np.array([1.5, 2.5]), "x", "categorical", 5, "tab10")
+
     def test_cmap_hex_count_and_format(self):
         """``_cmap_hex`` returns the requested number of hex colours."""
         colors = WebMap()._cmap_hex("viridis", 4)

--- a/tests/test_web_vector.py
+++ b/tests/test_web_vector.py
@@ -197,6 +197,18 @@ class TestDecorationNeedsEngine:
         m2 = WebMap().polygons(polygons_gdf).controls()
         assert len(m2.layers) == 3, "default controls() adds navigation + scale only"
 
+    def test_measure_registers_draw_tool(self, polygons_gdf):
+        """ED.10 — measure() adds a draw-based tool and the map still renders."""
+        from maplibre.ipywidget import MapWidget
+
+        m = WebMap().polygons(polygons_gdf).measure(distance=True, area=True)
+        assert len(m.layers) == 2, "data layer + the measure draw control"
+        assert isinstance(m.render(), MapWidget)
+
+    def test_measure_requires_a_mode(self, polygons_gdf):
+        with pytest.raises(ValueError, match="distance and/or area"):
+            WebMap().polygons(polygons_gdf).measure(distance=False, area=False)
+
 
 class TestAttributeTemplate:
     """``_attribute_template`` builds the right popup/tooltip kwargs (no engine needed)."""

--- a/tests/test_web_vector.py
+++ b/tests/test_web_vector.py
@@ -85,6 +85,23 @@ class TestColorExpr:
         stops = [expr[i] for i in range(3, len(expr), 2)]
         assert stops[0] < stops[-1], "constant data must still yield an increasing ramp"
 
+    def test_categorical_match_expression(self):
+        """scheme='categorical' compiles a MapLibre `match` over the distinct values (DC.8)."""
+        m = WebMap()
+        expr = m._color_expr(np.array(["a", "b", "a", "c"], dtype=object), "kind", "categorical", 5, "tab10")
+        assert expr[0] == "match", f"categorical colouring must be a match expression, got {expr[0]!r}"
+        assert expr[1] == ["get", "kind"], "the match input must read the column with ['get', column]"
+        assert expr[2] == "a" and expr[4] == "b" and expr[6] == "c", f"category literals misordered: {expr}"
+        assert expr[-1] == "#cccccc", "the match expression must end with a default colour"
+        assert m.last_breaks == ["a", "b", "c"], f"categories should be recorded: {m.last_breaks}"
+
+    def test_categorical_numeric_literals_are_json_native(self):
+        """Numeric categories are coerced to native int for the MapLibre literal."""
+        m = WebMap()
+        expr = m._color_expr(np.array([1, 2, 1, 3]), "code", "categorical", 5, "tab10")
+        literals = [expr[i] for i in range(2, len(expr) - 1, 2)]
+        assert literals == [1, 2, 3] and all(type(v) is int for v in literals)
+
     def test_cmap_hex_count_and_format(self):
         """``_cmap_hex`` returns the requested number of hex colours."""
         colors = WebMap()._cmap_hex("viridis", 4)

--- a/tests/test_web_vector.py
+++ b/tests/test_web_vector.py
@@ -222,6 +222,13 @@ class TestDecorationNeedsEngine:
         with pytest.raises(ValueError, match="distance and/or area"):
             WebMap().polygons(polygons_gdf).measure(distance=False, area=False)
 
+    def test_control_position_is_validated(self):
+        """An unknown control corner fails fast with a clear error rather than at render time (N3)."""
+        with pytest.raises(ValueError, match="unknown control position"):
+            WebMap().navigation(position="middle")
+        with pytest.raises(ValueError, match="unknown control position"):
+            WebMap().scale_bar(position="nowhere")
+
 
 class TestAttributeTemplate:
     """``_attribute_template`` builds the right popup/tooltip kwargs (no engine needed)."""

--- a/tests/test_web_vector.py
+++ b/tests/test_web_vector.py
@@ -182,6 +182,21 @@ class TestDecorationNeedsEngine:
         assert len(m.layers) == 2
         assert isinstance(m.render(), MapWidget)
 
+    def test_navigation_scale_fullscreen_controls_render(self, polygons_gdf):
+        """ED.13 — nav/scale/fullscreen controls register and the map still renders."""
+        from maplibre.ipywidget import MapWidget
+
+        m = WebMap().polygons(polygons_gdf).navigation().scale_bar(unit="imperial").fullscreen()
+        assert len(m.layers) == 4, "data layer + 3 controls"
+        assert isinstance(m.render(), MapWidget)
+
+    def test_controls_convenience(self, polygons_gdf):
+        """ED.13 — controls() adds navigation + scale (+ fullscreen) in one call."""
+        m = WebMap().polygons(polygons_gdf).controls(fullscreen=True)
+        assert len(m.layers) == 4, "data layer + navigation + scale + fullscreen"
+        m2 = WebMap().polygons(polygons_gdf).controls()
+        assert len(m2.layers) == 3, "default controls() adds navigation + scale only"
+
 
 class TestAttributeTemplate:
     """``_attribute_template`` builds the right popup/tooltip kwargs (no engine needed)."""

--- a/tests/test_web_vector.py
+++ b/tests/test_web_vector.py
@@ -174,8 +174,10 @@ class TestDecorationNeedsEngine:
         pytest.importorskip("maplibre")
 
     def test_basemap_unknown_provider_raises(self):
-        with pytest.raises(ValueError, match="unknown basemap provider"):
+        with pytest.raises(ValueError, match="unknown basemap provider") as exc:
             WebMap().basemap("NoSuchProvider")
+        # the suggestion list uses the canonical, correctly-cased names, not "Cartodark"/"Osm" (N1)
+        assert "CartoDark" in str(exc.value) and "OSM" in str(exc.value), f"mis-cased names: {exc.value}"
 
     def test_basemap_registers_an_underlay(self, polygons_gdf):
         """A basemap added after data is still drawn first (underlay at index 0)."""
@@ -221,6 +223,9 @@ class TestDecorationNeedsEngine:
     def test_measure_requires_a_mode(self, polygons_gdf):
         with pytest.raises(ValueError, match="distance and/or area"):
             WebMap().polygons(polygons_gdf).measure(distance=False, area=False)
+        # the mode guard is checked before position, so it wins when both are invalid (N4)
+        with pytest.raises(ValueError, match="distance and/or area"):
+            WebMap().polygons(polygons_gdf).measure(distance=False, area=False, position="bad")
 
     def test_control_position_is_validated(self):
         """An unknown control corner fails fast with a clear error rather than at render time (N3)."""


### PR DESCRIPTION
# Description

Implements the buildable Area E (charts & symbology) roadmap tasks plus two web-tier controls — all additive,
with **no new dependencies** (no `pyproject` / `pixi.lock` changes). One commit per task.

**Charts** (`charts.py`, over cleopatra glyphs; shared field/aggregation helpers):
- **DC.5** `statistics(data, column=…)` — count/min/max/mean/std + quantiles of a field.
- **DC.1** `histogram(gdf, column=…)` — one-call field histogram.
- **DC.3** `scatter(x, y, data=…, color_by=…, size_by=…)` — field-vs-field scatter.
- **DC.4** `bar_by` / `line_by` — aggregate (sum/mean/count/…) by category or time.
- **DC.6** `digitalearth.interactive.charts` — the HoloViz/Bokeh counterparts (histogram/scatter/bar/line/
  bar_by/line_by) returning HoloViews elements; field logic shared with `charts.py`.

**Symbology — DC.8** (categorized / distinct-value):
- `_symbology.categorical_colors` — the categorical counterpart of `cleopatra.styles.classify`.
- `choropleth(scheme="categorical")`: **web** compiles a MapLibre `["match", …]` expression; **interactive**
  passes a list cmap to GeoViews; **static** raises a clear `NotImplementedError` — cleopatra's `PolygonGlyph`
  colours by a continuous/graduated scale only (no per-distinct-value path), filed as an upstream cleopatra
  note. Graduated (`scheme="quantiles"`/`"fisher_jenks"`/…) is unchanged and still works in all three tiers.

**Web controls**:
- **ED.13** `navigation` / `scale_bar` / `fullscreen` + a `controls()` convenience (MapLibre `add_control`).
  No minimap — py-maplibregl has no built-in minimap control (noted; would need a custom JS control).
- **ED.10** `measure` — a draw-based distance/area tool (MapLibre draw control scoped to line/polygon); the
  drawn geometry is exposed on the widget, with geodesic distance/area left to pyramids (the GIS part).

Interactive `scheme="categorical"` renders one discrete colour per distinct value on numeric columns too:
the colour column is cast to a string label and handed to GeoViews as a `{label: colour}` dict cmap, so it is
not interpolated as a continuous palette (assumes a single-dtype attribute column). The static categorical gap
is tracked for upstream cleopatra.

Closes the Area E charts & symbology tasks from the roadmap:

- Closes #111 — DC.1: one-call `histogram(gdf, column)` field path
- Closes #112 — DC.3: field-vs-field `scatter`
- Closes #113 — DC.4: aggregate-by-category/time `bar_by`/`line_by`
- Closes #114 — DC.5: field `statistics` summary (min/max/mean/quantiles)
- Closes #115 — DC.6: interactive HoloViz charts
- Closes #116 — DC.8: categorized (distinct-value) symbology

Also delivers the Area H web-map controls ED.13 (navigation/scale/fullscreen) and ED.10 (measure), tracked in
the master issue tracker rather than as separate issues.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

New/extended tests per task; engine-dependent tests run in their pixi env, the rest in `dev`.

- [x] `pixi run -e dev pytest tests/test_charts.py tests/test_symbology.py tests/test_scheme.py
      tests/test_interactive_charts.py tests/test_no_competitor_imports.py` → **52 passed, 6 skipped**.
- [x] `pixi run -e web pytest tests/test_web_*.py` → **105 passed, 1 skipped**.
- [x] `pixi run -e interactive pytest tests/test_interactive_*.py` → **243 passed, 2 skipped**.
- [x] `python -m doctest` clean for the changed modules (`charts.py`, `_symbology.py`, web `vector`/
      `decoration`).

Test configuration: Windows 11, pixi `dev`/`web`/`interactive` envs, Python 3.13, `MPLBACKEND=Agg`.

# Checklist:

- [ ] updated version number in setup.py/pyproject.toml — N/A (version bumped by commitizen in CI)
- [ ] updated environment.yml and the lock file — N/A (no new dependencies)
- [ ] added changes to History.rst — N/A (changelog generated by commitizen in CI)
- [ ] updated the latest version in README file — N/A
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
