### PR TITLE
feat(scene): colour static choropleths by distinct value (scheme="categorical")

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -91,7 +91,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/36/0b805d8c485f872f65a509cbe3b58a5d0d17bee855333b54a150c79d3061/fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -189,7 +189,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/60/74ea344b3b003fada346ed98a6899085d6fd4c777df608992d90c458fda6/cftime-1.6.5-cp313-cp313-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/71/d935dc54e4ff121bfdd11e08702db63a7e6f25af21d8a3d7b7212df53641/fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl
@@ -281,7 +281,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -412,7 +412,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -658,7 +658,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/60/74ea344b3b003fada346ed98a6899085d6fd4c777df608992d90c458fda6/cftime-1.6.5-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -894,7 +894,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -1147,7 +1147,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -1369,7 +1369,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2e/60/74ea344b3b003fada346ed98a6899085d6fd4c777df608992d90c458fda6/cftime-1.6.5-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -1584,7 +1584,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -1825,7 +1825,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -2096,7 +2096,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/60/74ea344b3b003fada346ed98a6899085d6fd4c777df608992d90c458fda6/cftime-1.6.5-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -2357,7 +2357,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -2633,7 +2633,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -2825,7 +2825,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2e/60/74ea344b3b003fada346ed98a6899085d6fd4c777df608992d90c458fda6/cftime-1.6.5-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -3010,7 +3010,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl
@@ -3221,7 +3221,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/8d/86586c0d75110f774e46e2bd6d134e2d1cca1dedc9bb08c388fa3df76acd/cftime-1.6.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -3470,7 +3470,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/f6/9da7aba9548ede62d25936b8b448acd7e53e5dcc710896f66863dcc9a318/cftime-1.6.5-cp311-cp311-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -3709,7 +3709,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/c7/6669708fcfe1bb7b2a7ce693b8cc67165eac00d3ac5a5e8f6ce1be551ff9/cftime-1.6.5-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -3969,7 +3969,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/fd/a7266970312df65e68b5641b86e0540a739182f5e9c62eec6dbd29f18055/cftime-1.6.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -4214,7 +4214,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/c1/e8cb7f78a3f87295450e7300ebaecf83076d96a99a76190593d4e1d2be40/cftime-1.6.5-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -4449,7 +4449,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/15/8856a0ab76708553ff597dd2e617b088c734ba87dc3fd395e2b2f3efffe8/cftime-1.6.5-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -4706,7 +4706,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -4952,7 +4952,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/60/74ea344b3b003fada346ed98a6899085d6fd4c777df608992d90c458fda6/cftime-1.6.5-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -5188,7 +5188,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -5449,7 +5449,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/1a/aff8bb287a4b1400f69e09a53bd65de96aa5cee5691925b38731c67fc695/click_default_group-1.2.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/7b/97754548e9da3d41d7334e375b2cd712e9406a3f48823a5f0a166f42d63d/cmocean-4.0.3-py3-none-any.whl
@@ -5727,7 +5727,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/60/74ea344b3b003fada346ed98a6899085d6fd4c777df608992d90c458fda6/cftime-1.6.5-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/1a/aff8bb287a4b1400f69e09a53bd65de96aa5cee5691925b38731c67fc695/click_default_group-1.2.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/7b/97754548e9da3d41d7334e375b2cd712e9406a3f48823a5f0a166f42d63d/cmocean-4.0.3-py3-none-any.whl
@@ -5995,7 +5995,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/1a/aff8bb287a4b1400f69e09a53bd65de96aa5cee5691925b38731c67fc695/click_default_group-1.2.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/7b/97754548e9da3d41d7334e375b2cd712e9406a3f48823a5f0a166f42d63d/cmocean-4.0.3-py3-none-any.whl
@@ -6286,7 +6286,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -6546,7 +6546,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/60/74ea344b3b003fada346ed98a6899085d6fd4c777df608992d90c458fda6/cftime-1.6.5-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -6796,7 +6796,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -7724,10 +7724,10 @@ packages:
   version: 3.4.7
   sha256: e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/56/ac/64828b1fad7e32ff7fb483eacafff5e80750a889ac3259a1dfb4f5ff779c/cleopatra-0.25.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/6c/cf/998205896a3f085c88cc7815d6b54570d6ff0b679d660b5ac0592bc4f7dc/cleopatra-0.26.0-py3-none-any.whl
   name: cleopatra
-  version: 0.25.0
-  sha256: fd0cef30969fcbfe0e057a8d9b29e6a584b7424e2aac07354bb23896d3e76254
+  version: 0.26.0
+  sha256: f48e9811d1cd60d644beaf37ad180dc7476cdc714957d576b1a340c7c5850bf3
   requires_dist:
   - hpc-utils>=0.1.4
   - imageio-ffmpeg>=0.4.9
@@ -8254,11 +8254,11 @@ packages:
 - pypi: ./
   name: digitalearth
   version: 0.7.0
-  sha256: 9506e9f9daac1897aae9d1bc0440c05b34aad2488d84d69b8f7f1bd5d00c2a1f
+  sha256: 50b53066ef3af99414cfccf3d63851d6fe764cf5234b3316e41a71953693f17c
   requires_dist:
   - numpy>=2.0.0
   - geopandas>=1.1.3
-  - cleopatra>=0.25.0
+  - cleopatra>=0.26.0
   - pyramids-gis>=0.46.0
   - loguru>=0.7.3
   - pyyaml>=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">= 3.11, <4"
 dependencies = [
     "numpy >=2.0.0",
     "geopandas >=1.1.3",
-    "cleopatra >=0.25.0",
+    "cleopatra >=0.26.0",
     "pyramids-gis >=0.46.0",
     "loguru >=0.7.3",
     "pyyaml >=6.0",

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -63,15 +63,16 @@ def resolve_categorical_cmap(cmap: Any = None) -> Any:
     .. warning::
         One divergence remains and is **not** fixable from this side: ``cmap="coolwarm_r"`` is cleopatra's own
         sentinel, so the static tier swaps it for ``tab10`` while the web/interactive tiers honour it. Passing
-        cleopatra's continuous default explicitly to a categorical map is a pathological case (it renders
-        near-identically either way — see the qualitative-colormap note below); it needs an upstream change to
-        settle. Tracked in `planning/geolibre-parity/upstream-cleopatra-categorical.md`.
+        cleopatra's continuous default explicitly to a categorical map is a pathological edge; it needs an
+        upstream change to settle. Tracked in `planning/geolibre-parity/upstream-cleopatra-categorical.md`.
 
     A **qualitative** (``ListedColormap``) colormap is what belongs here — ``tab10``, ``tab20``, ``Set1``,
-    ``Set2``, ``Paired``. A continuous map (``viridis``, ``plasma``, ``coolwarm``) is honoured as given but
-    reads poorly: category colours are drawn at the colormap's first ``n`` LUT entries, which for a 256-entry
-    continuous map are near-identical shades. To build categories from a continuous map, sample it yourself and
-    pass the resulting ``ListedColormap``.
+    ``Set2``, ``Paired``. A continuous map is honoured as given, and how well it reads depends on its matplotlib
+    type: a ``LinearSegmentedColormap`` (``coolwarm``, ``RdBu``, ``jet``) is sampled at ``n`` evenly-spaced
+    points, so the categories stay distinct; a perceptual ``ListedColormap`` (``viridis``, ``plasma`` — 256
+    discrete entries) contributes its first ``n``, which are near-identical shades and read poorly. Either way
+    :func:`categorical_colors` and cleopatra sample it identically, so the tiers agree. To spread a perceptual
+    map across the categories, sample it into a shorter ``ListedColormap`` yourself.
 
     Args:
         cmap: The colormap passed to ``choropleth`` (a qualitative map is preferred for categorical), or
@@ -208,12 +209,19 @@ def categorical_colors(
     """Map the distinct values of a field to colours from a qualitative colormap (DC.8).
 
     The categorical analog of ``cleopatra.styles.classify``: instead of binning a continuous range, it assigns
-    one colour per distinct value. Colours cycle through ``cmap`` when there are more categories than the
-    colormap has entries.
+    one colour per distinct value. The colour sampling mirrors ``cleopatra.styles.categorize`` **exactly**, so
+    the web/interactive tiers (which consume this) and the static tier (which consumes cleopatra) render one
+    ``cmap`` as the same colours — a qualitative ``ListedColormap`` (``tab10``/``Set2``/…) contributes its
+    palette entries in order, cycling when there are more categories than colours, while a continuous
+    ``LinearSegmentedColormap`` (``coolwarm``/``RdBu``/…) is sampled at ``n`` **evenly-spaced** points so the
+    categories stay visually distinct rather than collapsing to the first few near-identical LUT entries. This
+    parity is pinned by ``tests/test_symbology.py::test_matches_cleopatra_categorize``.
 
     Args:
-        values: An array-like of category labels (strings or numbers); ``None``/``NaN`` are ignored.
-        cmap: A matplotlib (preferably qualitative) colormap name, e.g. ``"tab10"``/``"tab20"``/``"Set2"``.
+        values: An array-like of category labels (strings or numbers); nulls (``None``/``NaN``/``pd.NA``) are
+            ignored (see :func:`is_null`).
+        cmap: A matplotlib colormap name; a qualitative one (``"tab10"``/``"tab20"``/``"Set2"``) is preferred,
+            but a continuous map is sampled evenly and honoured too.
 
     Returns:
         tuple[list, list[str]]: ``(categories, colors)`` — the distinct categories (sorted when sortable) and a
@@ -249,6 +257,13 @@ def categorical_colors(
     if not categories:
         raise ValueError("no non-null values to colour categorically")
     colormap = colormaps[cmap]
-    n_colors = getattr(colormap, "N", len(categories)) or len(categories)
-    colors = [to_hex(colormap(i % n_colors)) for i in range(len(categories))]
+    n = len(categories)
+    # Match cleopatra.styles.categorize exactly: a ListedColormap exposes its palette as `.colors` and cycles;
+    # a LinearSegmentedColormap has none, so sample it at n evenly-spaced points (not the first n LUT entries,
+    # which on a 256-entry map are near-identical). Keeping this identical to cleopatra is what makes one cmap
+    # render the same colours on the static tier (via cleopatra) and the web/interactive tiers (via here).
+    base_colors = getattr(colormap, "colors", None)
+    if base_colors is None:
+        base_colors = [colormap(x) for x in np.linspace(0.0, 1.0, n)]
+    colors = [to_hex(base_colors[i % len(base_colors)]) for i in range(n)]
     return categories, colors

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -4,13 +4,20 @@ Graduated / continuous classification lives upstream in ``cleopatra.styles.class
 module is the **categorical** counterpart: map each distinct value of a field to a colour from a qualitative
 colormap, to colour by an unordered attribute (land-use class, region name, …).
 
-Scope: the **web** and **interactive** tiers only. The static tier takes its categorical mapping from cleopatra
-(``scheme="categorical"`` → ``Glyph._prepare_categorical_mapping``, cleopatra >=0.26.0), the canonical home for
-this colour work. What remains here is not a duplicate of it but a different *output shape*: cleopatra builds a
-matplotlib ``ListedColormap`` + ``BoundaryNorm`` bound to a glyph, whereas MapLibre needs a literal
-``["match", …]`` colour expression and GeoViews a plain ``{value: colour}`` dict — neither can consume a
-matplotlib mappable, so both tiers need the category→colour pairs as plain data. The ordering rule (sorted when
-sortable, else first-seen) is shared with cleopatra's ``styles.categorize``, so the classes agree across tiers.
+This module has two distinct jobs, with **different scopes** — do not conflate them:
+
+1. :func:`resolve_categorical_cmap` — the **cmap sentinel, shared by all three tiers** (static, interactive,
+   web). Every tier resolves ``cmap`` through it before colouring, so one ``cmap`` cannot mean two different
+   things depending on which tier renders it. The static tier must call it *before* handing off to cleopatra
+   (see the function's own note on the sentinel mismatch).
+2. :func:`categorical_colors` (and :func:`_categories`) — the category→colour **compiler, for the web and
+   interactive tiers only**. The static tier takes its mapping from cleopatra instead (``scheme="categorical"``
+   → ``Glyph._prepare_categorical_mapping``, cleopatra >=0.26.0), the canonical home for this colour work. What
+   remains here is not a duplicate of it but a different *output shape*: cleopatra builds a matplotlib
+   ``ListedColormap`` + ``BoundaryNorm`` bound to a glyph, whereas MapLibre needs a literal ``["match", …]``
+   colour expression and GeoViews a plain ``{value: colour}`` dict — neither can consume a matplotlib mappable,
+   so both tiers need the category→colour pairs as plain data. The ordering rule (sorted when sortable, else
+   first-seen) is shared with cleopatra's ``styles.categorize``, so the classes agree across tiers.
 """
 
 from typing import Any, List, Tuple
@@ -25,29 +32,57 @@ _DEFAULT_CATEGORICAL_CMAP = "tab10"
 _CONTINUOUS_DEFAULT_CMAP = "viridis"
 
 
-def resolve_categorical_cmap(cmap: str) -> str:
+def resolve_categorical_cmap(cmap: Any = None) -> Any:
     """Pick the colormap for categorical symbology, swapping the continuous default for a qualitative one.
 
     ``choropleth``'s ``cmap`` defaults to the continuous ``"viridis"`` (right for graduated/continuous
     colouring). That sequential map reads poorly as discrete categories, so when the caller leaves the default
     in place it is swapped for :data:`_DEFAULT_CATEGORICAL_CMAP`; any other explicit ``cmap`` is honoured.
 
+    **This is the single sentinel for every tier** — static, interactive and web all resolve ``cmap`` through
+    here before colouring, so one ``cmap`` cannot mean two different things depending on the tier. The static
+    tier must resolve *before* handing off to cleopatra, whose ``PolygonGlyph`` applies the same idea against a
+    **different** sentinel (its own continuous default, ``"coolwarm_r"``): left to itself it would honour an
+    explicit ``"viridis"`` that the sibling tiers swap for ``tab10``.
+
     Note this cannot distinguish "caller left the default" from "caller explicitly passed ``"viridis"``" — both
     are swapped to the qualitative default. To force a viridis categorical map, pass a distinct spelling such as
     ``"viridis_r"`` (or sample viridis yourself); this is deliberate, since viridis rarely reads well as
     discrete categories.
 
+    .. warning::
+        One divergence remains and is **not** fixable from this side: ``cmap="coolwarm_r"`` is cleopatra's own
+        sentinel, so the static tier swaps it for ``tab10`` while the web/interactive tiers honour it. Passing
+        cleopatra's continuous default explicitly to a categorical map is a pathological case (it renders
+        near-identically either way — see the qualitative-colormap note below); it needs an upstream change to
+        settle. Tracked in `planning/geolibre-parity/upstream-cleopatra-categorical.md`.
+
+    A **qualitative** (``ListedColormap``) colormap is what belongs here — ``tab10``, ``tab20``, ``Set1``,
+    ``Set2``, ``Paired``. A continuous map (``viridis``, ``plasma``, ``coolwarm``) is honoured as given but
+    reads poorly: category colours are drawn at the colormap's first ``n`` LUT entries, which for a 256-entry
+    continuous map are near-identical shades. To build categories from a continuous map, sample it yourself and
+    pass the resulting ``ListedColormap``.
+
     Args:
-        cmap: The colormap name passed to ``choropleth`` (a qualitative map is preferred for categorical).
+        cmap: The colormap passed to ``choropleth`` (a qualitative map is preferred for categorical), or
+            ``None``/omitted when the caller supplied none — which resolves to the qualitative default.
 
     Returns:
-        ``cmap`` unchanged, unless it is the continuous default — then the qualitative categorical default.
+        ``cmap`` unchanged, unless it is ``None`` or the continuous default — then the qualitative categorical
+        default.
 
     Examples:
         - The continuous default is swapped for a qualitative colormap:
             ```python
             >>> from digitalearth._symbology import resolve_categorical_cmap
             >>> resolve_categorical_cmap("viridis")
+            'tab10'
+
+            ```
+        - No colormap at all resolves to the same qualitative default:
+            ```python
+            >>> from digitalearth._symbology import resolve_categorical_cmap
+            >>> resolve_categorical_cmap()
             'tab10'
 
             ```
@@ -59,7 +94,8 @@ def resolve_categorical_cmap(cmap: str) -> str:
 
             ```
     """
-    return _DEFAULT_CATEGORICAL_CMAP if cmap == _CONTINUOUS_DEFAULT_CMAP else cmap
+    left_at_default = cmap is None or cmap == _CONTINUOUS_DEFAULT_CMAP
+    return _DEFAULT_CATEGORICAL_CMAP if left_at_default else cmap
 
 
 def _categories(values: Any) -> List[Any]:

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -27,6 +27,13 @@ import numpy as np
 #: Default qualitative colormap for categorical symbology (10 distinct hues; cycled if more categories).
 _DEFAULT_CATEGORICAL_CMAP = "tab10"
 
+#: Neutral colour for a feature whose category is missing (``NaN``/``None``/``pd.NA``). Shared by all three
+#: tiers — the web tier's ``["match", …]`` fallback, the interactive tier's dict-cmap fallback, and the static
+#: tier's colormap "bad" colour — so missing data reads as *missing* rather than as absent, identically
+#: everywhere. Keep this a single constant: two tiers spelling the same idea differently is exactly how the
+#: ``cmap`` sentinels drifted apart.
+MISSING_COLOR = "#cccccc"
+
 #: The continuous-colour default ``choropleth`` carries in its signature (right for graduated/continuous,
 #: a poor fit for categorical). The categorical path swaps it for ``_DEFAULT_CATEGORICAL_CMAP``.
 _CONTINUOUS_DEFAULT_CMAP = "viridis"

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -23,6 +23,7 @@ This module has two distinct jobs, with **different scopes** — do not conflate
 from typing import Any, List, Tuple
 
 import numpy as np
+import pandas as pd
 
 #: Default qualitative colormap for categorical symbology (10 distinct hues; cycled if more categories).
 _DEFAULT_CATEGORICAL_CMAP = "tab10"
@@ -105,11 +106,82 @@ def resolve_categorical_cmap(cmap: Any = None) -> Any:
     return _DEFAULT_CATEGORICAL_CMAP if left_at_default else cmap
 
 
+def is_null(value: Any) -> bool:
+    """Return whether ``value`` is missing, in any of the spellings a dataframe column can produce.
+
+    A category column can carry its nulls as ``None`` (object dtype), ``float("nan")`` (numeric dtype), or
+    ``pd.NA``/``pd.NaT`` (pandas' nullable ``string``/``Int64``/``boolean``/datetime dtypes — increasingly the
+    default for anything round-tripped through modern pandas or pyarrow). All three mean "no data" and must
+    never become a category: a bogus ``<NA>`` class would take a palette colour and shift every subsequent
+    category's colour by one, so the same logical data would render differently purely by dtype.
+
+    Args:
+        value: A single scalar from a category column.
+
+    Returns:
+        ``True`` when the value is any flavour of null, else ``False``.
+
+    Examples:
+        - Every spelling of missing is caught, and real categories are kept:
+            ```python
+            >>> import numpy as np
+            >>> import pandas as pd
+            >>> from digitalearth._symbology import is_null
+            >>> [is_null(v) for v in (None, np.nan, pd.NA, pd.NaT)]
+            [True, True, True, True]
+            >>> [is_null(v) for v in ("urban", 0, False)]
+            [False, False, False]
+
+            ```
+    """
+    try:
+        result = bool(pd.isna(value))
+    except (TypeError, ValueError):
+        # A list-like or otherwise non-scalar value: `pd.isna` returns an elementwise array whose truth value
+        # is ambiguous. Such a value is not a null, it is (an unhashable) category — let it flow on.
+        result = False
+    return result
+
+
+def nulls_to_none(values: Any) -> np.ndarray:
+    """Return ``values`` as an object array with every flavour of null spelled ``None``.
+
+    The static tier's mapping is built by cleopatra, whose null test is ``value is None`` plus a float-``NaN``
+    check — so a ``pd.NA`` from a pandas nullable dtype survives it and becomes a real, coloured ``<NA>``
+    category. Normalizing the nulls to the one spelling cleopatra recognises keeps the static tier's classes
+    identical to the web/interactive tiers' (which drop them via :func:`is_null`), without reaching into
+    cleopatra. The underlying gap is upstream and is reported there, not patched here.
+
+    Args:
+        values: An array-like of category labels.
+
+    Returns:
+        An object-dtype copy with all nulls replaced by ``None``. Non-null values are untouched.
+
+    Examples:
+        - `pd.NA` is normalized to `None`, so it cannot become a category:
+            ```python
+            >>> import pandas as pd
+            >>> from digitalearth._symbology import nulls_to_none
+            >>> nulls_to_none(pd.array(["urban", pd.NA], dtype="string")).tolist()
+            ['urban', None]
+
+            ```
+    """
+    array = np.asarray(values, dtype=object)
+    missing = np.array([is_null(value) for value in array.ravel()]).reshape(array.shape)
+    if missing.any():
+        array = array.copy()
+        array[missing] = None
+    return array
+
+
 def _categories(values: Any) -> List[Any]:
     """Return the distinct, non-null values of ``values`` in a stable order (sorted when sortable).
 
     Args:
-        values: An array-like of category labels (strings or numbers); ``None``/``NaN`` are dropped.
+        values: An array-like of category labels (strings or numbers); nulls (``None``/``NaN``/``pd.NA``) are
+            dropped — see :func:`is_null`.
 
     Returns:
         The unique categories, sorted ascending when they are mutually comparable, else in first-seen order.
@@ -117,9 +189,7 @@ def _categories(values: Any) -> List[Any]:
     seen: List[Any] = []
     seen_set: set = set()  # O(1) membership so dedup stays O(n), not O(n·k), for large columns
     for value in np.asarray(values, dtype=object).ravel():
-        if value is None:
-            continue
-        if isinstance(value, float) and np.isnan(value):
+        if is_null(value):
             continue
         if value not in seen_set:
             seen_set.add(value)

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -173,12 +173,9 @@ def nulls_to_none(values: Any) -> np.ndarray:
             ```
     """
     array = np.asarray(values, dtype=object)
-    try:
-        missing = np.asarray(pd.isna(array), dtype=bool)
-        if missing.shape != array.shape:  # a non-elementwise result (e.g. a list-like cell) — fall back
-            raise ValueError
-    except (TypeError, ValueError):
-        missing = np.array([is_null(value) for value in array.ravel()], dtype=bool).reshape(array.shape)
+    # `pd.isna` on an object array is reliably elementwise (a list/tuple/dict/set/ndarray cell reads as a
+    # non-null value, matching :func:`is_null`), so one vectorized call suffices — no per-element loop.
+    missing = np.asarray(pd.isna(array), dtype=bool)
     if missing.any():
         array = array.copy()
         array[missing] = None

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -159,7 +159,8 @@ def nulls_to_none(values: Any) -> np.ndarray:
         values: An array-like of category labels.
 
     Returns:
-        An object-dtype copy with all nulls replaced by ``None``. Non-null values are untouched.
+        An object-dtype array with all nulls replaced by ``None`` and non-null values untouched. Copied only
+        when a null is actually rewritten; a null-free input may be returned as-is.
 
     Examples:
         - `pd.NA` is normalized to `None`, so it cannot become a category:
@@ -172,7 +173,12 @@ def nulls_to_none(values: Any) -> np.ndarray:
             ```
     """
     array = np.asarray(values, dtype=object)
-    missing = np.array([is_null(value) for value in array.ravel()]).reshape(array.shape)
+    try:
+        missing = np.asarray(pd.isna(array), dtype=bool)
+        if missing.shape != array.shape:  # a non-elementwise result (e.g. a list-like cell) — fall back
+            raise ValueError
+    except (TypeError, ValueError):
+        missing = np.array([is_null(value) for value in array.ravel()], dtype=bool).reshape(array.shape)
     if missing.any():
         array = array.copy()
         array[missing] = None

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -2,12 +2,15 @@
 
 Graduated / continuous classification lives upstream in ``cleopatra.styles.classify`` (numeric breaks); this
 module is the **categorical** counterpart: map each distinct value of a field to a colour from a qualitative
-colormap. It is pure numpy + matplotlib colour work (styling, not GIS), consumed by the tiers' ``choropleth``
-``scheme="categorical"`` path to colour by an unordered attribute (land-use class, region name, …).
+colormap, to colour by an unordered attribute (land-use class, region name, …).
 
-The mapping itself is generic colour work and is a candidate to move into cleopatra alongside ``classify``
-(tracked in ``planning/geolibre-parity/ISSUE-TRACKER.md`` / upstream note); it lives here for now because no
-cleopatra equivalent exists yet.
+Scope: the **web** and **interactive** tiers only. The static tier takes its categorical mapping from cleopatra
+(``scheme="categorical"`` → ``Glyph._prepare_categorical_mapping``, cleopatra >=0.26.0), the canonical home for
+this colour work. What remains here is not a duplicate of it but a different *output shape*: cleopatra builds a
+matplotlib ``ListedColormap`` + ``BoundaryNorm`` bound to a glyph, whereas MapLibre needs a literal
+``["match", …]`` colour expression and GeoViews a plain ``{value: colour}`` dict — neither can consume a
+matplotlib mappable, so both tiers need the category→colour pairs as plain data. The ordering rule (sorted when
+sortable, else first-seen) is shared with cleopatra's ``styles.categorize``, so the classes agree across tiers.
 """
 
 from typing import Any, List, Tuple

--- a/src/digitalearth/_symbology.py
+++ b/src/digitalearth/_symbology.py
@@ -17,7 +17,9 @@ This module has two distinct jobs, with **different scopes** — do not conflate
    ``ListedColormap`` + ``BoundaryNorm`` bound to a glyph, whereas MapLibre needs a literal ``["match", …]``
    colour expression and GeoViews a plain ``{value: colour}`` dict — neither can consume a matplotlib mappable,
    so both tiers need the category→colour pairs as plain data. The ordering rule (sorted when sortable, else
-   first-seen) is shared with cleopatra's ``styles.categorize``, so the classes agree across tiers.
+   first-seen) is **independently reimplemented** here (:func:`_categories`) and in cleopatra's
+   ``styles.categorize``, kept in agreement by ``tests/test_symbology.py::test_matches_cleopatra_categorize``
+   — not shared code, so a change on either side must be mirrored (the test is what catches a drift).
 """
 
 from typing import Any, List, Tuple

--- a/src/digitalearth/api.py
+++ b/src/digitalearth/api.py
@@ -173,7 +173,7 @@ def quickmap(
             pass
     if domain is not None:
         scene.set_domain()
-    if colorbar and scene.layers and scene.layers[-1][1] is not None:
+    if colorbar and scene.layers and scene.layers[-1][1] is not None and not _last_layer_is_categorical(scene):
         try:
             scene.colorbar()
         except Exception:  # outline-only / unmappable layer
@@ -362,12 +362,32 @@ def _quickmap_3d(data: PlottableData, *, colorbar: bool = True, **kwargs) -> Any
     return scene
 
 
+def _last_layer_is_categorical(scene: Map) -> bool:
+    """Return whether ``scene``'s most recent layer is a categorical fill (keyed by a swatch legend).
+
+    A categorical fill's mappable carries opaque integer class codes, so an aggregated colorbar over it would
+    read ``0, 1, 2 …`` instead of the category labels — the glyph draws its own swatch legend instead
+    (``PolygonGlyph.category_legend`` is set, non-categorical glyphs leave it ``None`` or absent). The one-call
+    wrappers must not add a colorbar on top of that legend.
+
+    Args:
+        scene: The :class:`Map` whose last layer is inspected.
+
+    Returns:
+        ``True`` when the last layer's glyph exposes a drawn ``category_legend``, else ``False``.
+    """
+    if not scene.layers:
+        return False
+    return getattr(scene.layers[-1][0], "category_legend", None) is not None
+
+
 def _finish(scene: Map, *, colorbar: bool) -> Map:
     """Add an aggregated colorbar to ``scene`` when requested and a mappable layer exists; return ``scene``.
 
     The shared tail of the one-call wrappers: a colorbar is added only when ``colorbar`` is true and a layer
     was drawn, and an outline-only / unmappable layer (which cannot carry a colorbar) is swallowed rather
-    than raised.
+    than raised. A categorical fill is skipped too — it keys itself with a swatch legend, and a colorbar over
+    its integer class codes would be a meaningless second key (see :func:`_last_layer_is_categorical`).
 
     Args:
         scene: The :class:`Map` a wrapper has already drawn on.
@@ -376,7 +396,7 @@ def _finish(scene: Map, *, colorbar: bool) -> Map:
     Returns:
         The same ``scene`` (so wrappers can ``return _finish(...)``).
     """
-    if colorbar and scene.layers:
+    if colorbar and scene.layers and not _last_layer_is_categorical(scene):
         try:
             scene.colorbar()
         except Exception:  # outline-only / unmappable layer

--- a/src/digitalearth/interactive/vector.py
+++ b/src/digitalearth/interactive/vector.py
@@ -260,7 +260,7 @@ class VectorMixin:
         Returns:
             This map (chainable).
         """
-        from digitalearth._symbology import categorical_colors, resolve_categorical_cmap
+        from digitalearth._symbology import MISSING_COLOR, categorical_colors, resolve_categorical_cmap
 
         gdf = self._display_gdf(features)
         categories, colors = categorical_colors(gdf[column], resolve_categorical_cmap(cmap))
@@ -276,8 +276,8 @@ class VectorMixin:
             sentinel += "_"
         gdf[column] = gdf[column].astype(str).mask(missing, sentinel)
         if missing.any():
-            # Missing values get an explicit neutral fallback, matching the web tier's "#cccccc" default.
-            cmap_by_label[sentinel] = "#cccccc"
+            # Missing values get an explicit neutral fallback, shared with the web and static tiers.
+            cmap_by_label[sentinel] = MISSING_COLOR
         element = self._vector_element("Polygons", gdf, vdims=[column])
         common = {"color": column, "cmap": cmap_by_label, "colorbar": False, **opts}
         element = self._styled(element, common=common, bokeh={"tools": ["hover"]})

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -199,7 +199,9 @@ class VectorMixin:
         Args:
             dataset: A pyramids ``Dataset`` (reprojected to the display CRS first).
             band: 1-based band whose values colour the cells.
-            **opts: Styling kwargs, filtered to ``PolygonGlyph``'s accepted options.
+            **opts: Styling kwargs, filtered to ``PolygonGlyph``'s accepted options. A ``scheme`` (including
+                ``scheme="categorical"``, keyed by a swatch legend) is honoured the same way :meth:`choropleth`
+                describes — see ``_polygon_layer``.
 
         Returns:
             The ``PolyCollection`` (registered as a Scene layer).
@@ -568,7 +570,9 @@ class VectorMixin:
                 to the display CRS) or a shapely geometry already in the display CRS. ``None`` leaves shapely's
                 default bounded cells.
             **opts: Styling kwargs forwarded to ``PolygonGlyph``. Pass ``scheme`` (e.g. ``"quantiles"`` /
-                ``"fisher_jenks"``) + ``k`` to colour cells by discrete classes instead of a continuous scale.
+                ``"fisher_jenks"``) + ``k`` to colour cells by discrete classes instead of a continuous scale,
+                or ``scheme="categorical"`` for one colour per distinct value (keyed by a swatch legend the same
+                way :meth:`choropleth` describes — see ``_polygon_layer``).
 
         Returns:
             The ``PolyCollection`` (registered as a Scene layer).
@@ -654,7 +658,9 @@ class VectorMixin:
             column: Optional column whose value colours each scaled polygon, or ``None`` for outlines only.
             limits: ``(min, max)`` scale factors mapped to the smallest/largest ``scale`` value.
             **opts: Styling kwargs forwarded to ``PolygonGlyph``. Pass ``scheme`` (e.g. ``"quantiles"`` /
-                ``"fisher_jenks"``) + ``k`` to colour by discrete classes instead of a continuous scale.
+                ``"fisher_jenks"``) + ``k`` to colour by discrete classes instead of a continuous scale, or
+                ``scheme="categorical"`` for one colour per distinct value (keyed by a swatch legend the same
+                way :meth:`choropleth` describes — see ``_polygon_layer``).
 
         Returns:
             The ``PolyCollection`` (registered as a Scene layer).
@@ -769,7 +775,9 @@ class VectorMixin:
             clip: Optional boundary the cells are clipped to (``FeatureCollection``/``GeoDataFrame`` reprojected,
                 or a shapely geometry in the display CRS). ``None`` keeps the full rectangular cells.
             **opts: Styling kwargs forwarded to ``PolygonGlyph``. Pass ``scheme`` (e.g. ``"quantiles"`` /
-                ``"fisher_jenks"``) + ``k`` to colour cells by discrete classes instead of a continuous scale.
+                ``"fisher_jenks"``) + ``k`` to colour cells by discrete classes instead of a continuous scale,
+                or ``scheme="categorical"`` for one colour per distinct value (keyed by a swatch legend the same
+                way :meth:`choropleth` describes — see ``_polygon_layer``).
 
         Returns:
             The ``PolyCollection`` (registered as a Scene layer).

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -19,7 +19,7 @@ from cleopatra.vector_glyph import VectorGlyph
 from pyramids.dataset import Dataset
 
 from digitalearth._arrays import NAN_REDUCERS, read_masked_band
-from digitalearth._symbology import MISSING_COLOR, resolve_categorical_cmap
+from digitalearth._symbology import MISSING_COLOR, nulls_to_none, resolve_categorical_cmap
 from digitalearth.sources import get_source
 
 #: Per-cell reducers accepted by ``Map.quadtree``'s ``agg`` — the shared NaN-aware registry plus a special
@@ -113,6 +113,12 @@ class VectorMixin:
             # default, "coolwarm_r"), so left to itself it would honour an explicit cmap="viridis" that the
             # web/interactive tiers swap for tab10 — one cmap, two maps.
             opts["cmap"] = resolve_categorical_cmap(opts.get("cmap"))
+            if values is not None:
+                # cleopatra's null test is `is None` plus a float-NaN check, so a `pd.NA` from a pandas
+                # nullable dtype (`string`, `Int64`, …) would survive it and become a coloured `<NA>` class,
+                # shifting every other category's colour — i.e. the same data would render differently
+                # depending only on the column's dtype.
+                values = nulls_to_none(values)
         if values is not None:
             glyph = PolygonGlyph(polygons, values=values, ax=self.ax, fig=self.fig, **opts)
             artist = self._render_glyph(glyph, artist="plot")

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -62,7 +62,12 @@ class VectorMixin:
 
         Consolidates the fill-vs-outline branch shared by :meth:`grid_cells`, :meth:`choropleth`,
         :meth:`shapes`, :meth:`voronoi`, :meth:`cartogram` and :meth:`quadtree`. The Scene owns the
-        aggregated colorbar, so the glyph's own colorbar is suppressed by default.
+        aggregated colorbar, so the glyph's own colorbar is suppressed by default — except under
+        ``scheme="categorical"``, where the value key is a per-class swatch legend the glyph builds from its
+        own mapping (``PolygonGlyph.category_legend``). The Scene's colorbar cannot stand in for it: a
+        categorical fill feeds the mappable opaque integer class codes, so a colorbar over them would read
+        ``0, 1, 2 …`` instead of the category labels. Pass ``add_colorbar=False`` explicitly to suppress the
+        legend and key the classes yourself via :meth:`~digitalearth.scene.scene.Scene.legend`.
 
         Args:
             polygons: Polygon rings as ``(N, 2)`` vertex arrays.
@@ -72,7 +77,8 @@ class VectorMixin:
         Returns:
             The ``PolyCollection`` (registered as a Scene layer).
         """
-        opts.setdefault("add_colorbar", False)  # the Scene owns the aggregated colorbar
+        categorical = str(opts.get("scheme", "")).lower() == "categorical"
+        opts.setdefault("add_colorbar", categorical)  # the Scene owns the colorbar; the glyph owns the legend
         if values is not None:
             glyph = PolygonGlyph(polygons, values=values, ax=self.ax, fig=self.fig, **opts)
             return self._render_glyph(glyph, artist="plot")
@@ -387,9 +393,15 @@ class VectorMixin:
 
         Args:
             features: A pyramids ``FeatureCollection`` of polygons (reprojected to the display CRS).
-            column: Name of the numeric column whose values colour the polygons.
+            column: Name of the column whose values colour the polygons — numeric for a continuous or
+                graduated scale, or any nominal labels (strings, region codes, …) under
+                ``scheme="categorical"``.
             **opts: Styling kwargs forwarded to ``PolygonGlyph``. Pass ``scheme`` (e.g. ``"quantiles"`` /
-                ``"fisher_jenks"``) + ``k`` to colour by discrete classes instead of a continuous scale.
+                ``"fisher_jenks"``) + ``k`` to colour by discrete classes instead of a continuous scale, or
+                ``scheme="categorical"`` to give every distinct value its own colour (an unordered attribute
+                such as a land-use class or region name — ``k`` does not apply, and ``vmin``/``vmax``/
+                ``levels``/``color_scale`` are ignored). A categorical fill is keyed by a swatch legend rather
+                than a colorbar, and defaults to the qualitative ``"tab10"`` unless ``cmap`` is given.
                 Note the default ``scheme`` differs by tier: this static tier (like the interactive
                 ``choropleth``) defaults to a **continuous** scale, whereas the **web** ``choropleth`` is
                 graduated-by-default (``"quantiles"``). Pass ``scheme`` explicitly for identical classification
@@ -413,14 +425,16 @@ class VectorMixin:
                 True
 
                 ```
+            - Colour by an unordered attribute — one colour per distinct class, keyed by a swatch legend:
+                ```python
+                >>> fc["zone"] = ["urban", "rural"] * (len(fc) // 2) + ["urban"] * (len(fc) % 2)
+                >>> m = Map(crs=fc.epsg)
+                >>> pc = m.choropleth(fc, column="zone", scheme="categorical")
+                >>> [t.get_text() for t in m.layers[-1][0].category_legend.get_texts()]
+                ['rural', 'urban']
+
+                ```
         """
-        if str(opts.get("scheme", "")).lower() == "categorical":
-            raise NotImplementedError(
-                "scheme='categorical' is not supported in the static tier: cleopatra's PolygonGlyph colours "
-                "by a continuous/graduated scale only (no per-distinct-value mapping) — tracked as an upstream "
-                "cleopatra gap. Use WebMap.choropleth(..., scheme='categorical') or the interactive tier; "
-                "graduated schemes (quantiles/fisher_jenks/…) work here."
-            )
         gdf = self._vector_input(features, geom_types=("Polygon", "MultiPolygon"), name="choropleth",
                                  geom_label="polygon")
         polygons, repeats = self._polygon_vertices(gdf.geometry)

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -450,11 +450,11 @@ class VectorMixin:
                 ``levels``/``color_scale`` are ignored). A categorical fill is keyed by a swatch legend rather
                 than a colorbar. For a categorical scheme, ``cmap`` should be a **qualitative**
                 (``ListedColormap``) map — ``"tab10"`` (the default), ``"Set2"``, ``"Paired"``, … A continuous
-                map (``"viridis"``, ``"plasma"``) is accepted but reads poorly: category colours are drawn from
-                its first *n* LUT entries, which on a 256-entry continuous map are near-identical shades (a known
-                cleopatra limitation — see `planning/geolibre-parity/upstream-cleopatra-categorical.md`); to
-                build categories from a continuous map, sample it into a ``ListedColormap`` yourself. Missing
-                values (``NaN``/``None``/``pd.NA``) are drawn a neutral grey, not dropped.
+                ``LinearSegmentedColormap`` (``"coolwarm"``, ``"RdBu"``) is sampled at evenly-spaced points so
+                the categories stay distinct; a perceptual ``ListedColormap`` (``"viridis"``, ``"plasma"``) is
+                accepted but reads poorly (its first *n* of 256 entries are near-identical shades). The colours
+                are identical to the web/interactive tiers either way. Missing values
+                (``NaN``/``None``/``pd.NA``) are drawn a neutral grey, not dropped.
                 Note the default ``scheme`` differs by tier: this static tier (like the interactive
                 ``choropleth``) defaults to a **continuous** scale, whereas the **web** ``choropleth`` is
                 graduated-by-default (``"quantiles"``). Pass ``scheme`` explicitly for identical classification

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -19,12 +19,31 @@ from cleopatra.vector_glyph import VectorGlyph
 from pyramids.dataset import Dataset
 
 from digitalearth._arrays import NAN_REDUCERS, read_masked_band
-from digitalearth._symbology import resolve_categorical_cmap
+from digitalearth._symbology import MISSING_COLOR, resolve_categorical_cmap
 from digitalearth.sources import get_source
 
 #: Per-cell reducers accepted by ``Map.quadtree``'s ``agg`` — the shared NaN-aware registry plus a special
 #: ``"count"`` (``len`` over the per-cell index array, ignoring the column).
 _QUADTREE_AGG = {**NAN_REDUCERS, "count": len}
+
+
+def _draw_missing_neutral(artist: Any) -> None:
+    """Colour a categorical layer's missing values neutral instead of invisible.
+
+    cleopatra maps a missing category to ``NaN`` in the class codes, and a ``ListedColormap``'s default "bad"
+    colour is fully transparent — so a feature whose attribute is missing is drawn as *nothing*, making it
+    indistinguishable from a feature that was never in the collection. The web and interactive tiers both draw
+    :data:`~digitalearth._symbology.MISSING_COLOR` there; this matches them, so missing data reads as missing on
+    all three tiers.
+
+    ``with_extremes`` returns a *new* colormap rather than mutating in place, which matters: the glyph's may be
+    a colormap registered globally under a name, and setting the bad colour on that instance would leak this
+    policy into every other plot in the process.
+
+    Args:
+        artist: The rendered mappable (a ``PolyCollection``) whose colormap gets the neutral "bad" colour.
+    """
+    artist.set_cmap(artist.get_cmap().with_extremes(bad=MISSING_COLOR))
 
 
 class VectorMixin:
@@ -96,7 +115,10 @@ class VectorMixin:
             opts["cmap"] = resolve_categorical_cmap(opts.get("cmap"))
         if values is not None:
             glyph = PolygonGlyph(polygons, values=values, ax=self.ax, fig=self.fig, **opts)
-            return self._render_glyph(glyph, artist="plot")
+            artist = self._render_glyph(glyph, artist="plot")
+            if categorical:
+                _draw_missing_neutral(artist)
+            return artist
         glyph = PolygonGlyph(polygons, ax=self.ax, fig=self.fig, **opts)
         return self._render_glyph(glyph, artist="plot", outline_only=True)
 

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -78,9 +78,17 @@ class VectorMixin:
         Returns:
             The ``PolyCollection`` (registered as a Scene layer).
         """
-        categorical = str(opts.get("scheme", "")).lower() == "categorical"
+        scheme = opts.get("scheme")
+        # `isinstance` states the intent: cleopatra's `classify` also accepts a list/ndarray of explicit bin
+        # edges as `scheme`, which must never be stringified into this comparison.
+        categorical = isinstance(scheme, str) and scheme.lower() == "categorical"
         opts.setdefault("add_colorbar", categorical)  # the Scene owns the colorbar; the glyph owns the legend
         if categorical:
+            # Normalize the spelling: cleopatra dispatches on an exact, case-sensitive `== "categorical"`, so a
+            # case variant would set up a categorical render here and then fall through to the continuous path
+            # there — dying inside `np.isfinite` on a string column. The web tier accepts any case, so
+            # normalizing (rather than matching cleopatra's exactness) keeps a `scheme` portable across tiers.
+            opts["scheme"] = "categorical"
             # Resolve the colormap here so all three tiers key off ONE sentinel. cleopatra applies the same
             # "swap the continuous default for a qualitative one" rule against a *different* sentinel (its own
             # default, "coolwarm_r"), so left to itself it would honour an explicit cmap="viridis" that the

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -86,8 +86,10 @@ class VectorMixin:
         ``scheme="categorical"``, where the value key is a per-class swatch legend the glyph builds from its
         own mapping (``PolygonGlyph.category_legend``). The Scene's colorbar cannot stand in for it: a
         categorical fill feeds the mappable opaque integer class codes, so a colorbar over them would read
-        ``0, 1, 2 …`` instead of the category labels. Pass ``add_colorbar=False`` explicitly to suppress the
-        legend and key the classes yourself via :meth:`~digitalearth.scene.scene.Scene.legend`.
+        ``0, 1, 2 …`` instead of the category labels. Passing ``add_colorbar=False`` suppresses that swatch
+        legend — for a caller keying the map some other way, e.g. drawing one shared legend across several
+        layers via :meth:`~digitalearth.scene.scene.Scene.legend` (which takes explicit ``colors``/``labels``;
+        read the drawn legend's swatches/texts off ``layer.category_legend`` to feed it).
 
         Args:
             polygons: Polygon rings as ``(N, 2)`` vertex arrays.
@@ -481,6 +483,9 @@ class VectorMixin:
                 >>> fc["zone"] = ["urban", "rural"] * (len(fc) // 2) + ["urban"] * (len(fc) % 2)
                 >>> m = Map(crs=fc.epsg)
                 >>> pc = m.choropleth(fc, column="zone", scheme="categorical")
+                >>> from matplotlib.colors import BoundaryNorm
+                >>> isinstance(pc.norm, BoundaryNorm)  # discrete class codes, not a continuous scale
+                True
                 >>> [t.get_text() for t in m.layers[-1][0].category_legend.get_texts()]
                 ['rural', 'urban']
 

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -19,6 +19,7 @@ from cleopatra.vector_glyph import VectorGlyph
 from pyramids.dataset import Dataset
 
 from digitalearth._arrays import NAN_REDUCERS, read_masked_band
+from digitalearth._symbology import resolve_categorical_cmap
 from digitalearth.sources import get_source
 
 #: Per-cell reducers accepted by ``Map.quadtree``'s ``agg`` — the shared NaN-aware registry plus a special
@@ -79,6 +80,12 @@ class VectorMixin:
         """
         categorical = str(opts.get("scheme", "")).lower() == "categorical"
         opts.setdefault("add_colorbar", categorical)  # the Scene owns the colorbar; the glyph owns the legend
+        if categorical:
+            # Resolve the colormap here so all three tiers key off ONE sentinel. cleopatra applies the same
+            # "swap the continuous default for a qualitative one" rule against a *different* sentinel (its own
+            # default, "coolwarm_r"), so left to itself it would honour an explicit cmap="viridis" that the
+            # web/interactive tiers swap for tab10 — one cmap, two maps.
+            opts["cmap"] = resolve_categorical_cmap(opts.get("cmap"))
         if values is not None:
             glyph = PolygonGlyph(polygons, values=values, ax=self.ax, fig=self.fig, **opts)
             return self._render_glyph(glyph, artist="plot")

--- a/src/digitalearth/scene/maps/vector.py
+++ b/src/digitalearth/scene/maps/vector.py
@@ -444,7 +444,13 @@ class VectorMixin:
                 ``scheme="categorical"`` to give every distinct value its own colour (an unordered attribute
                 such as a land-use class or region name — ``k`` does not apply, and ``vmin``/``vmax``/
                 ``levels``/``color_scale`` are ignored). A categorical fill is keyed by a swatch legend rather
-                than a colorbar, and defaults to the qualitative ``"tab10"`` unless ``cmap`` is given.
+                than a colorbar. For a categorical scheme, ``cmap`` should be a **qualitative**
+                (``ListedColormap``) map — ``"tab10"`` (the default), ``"Set2"``, ``"Paired"``, … A continuous
+                map (``"viridis"``, ``"plasma"``) is accepted but reads poorly: category colours are drawn from
+                its first *n* LUT entries, which on a 256-entry continuous map are near-identical shades (a known
+                cleopatra limitation — see `planning/geolibre-parity/upstream-cleopatra-categorical.md`); to
+                build categories from a continuous map, sample it into a ``ListedColormap`` yourself. Missing
+                values (``NaN``/``None``/``pd.NA``) are drawn a neutral grey, not dropped.
                 Note the default ``scheme`` differs by tier: this static tier (like the interactive
                 ``choropleth``) defaults to a **continuous** scale, whereas the **web** ``choropleth`` is
                 graduated-by-default (``"quantiles"``). Pass ``scheme`` explicitly for identical classification

--- a/src/digitalearth/web/vector.py
+++ b/src/digitalearth/web/vector.py
@@ -73,13 +73,13 @@ class VectorMixin:
             return value
 
         if isinstance(scheme, str) and scheme.lower() == "categorical":
-            from digitalearth._symbology import categorical_colors, resolve_categorical_cmap
+            from digitalearth._symbology import MISSING_COLOR, categorical_colors, resolve_categorical_cmap
 
             categories, colors = categorical_colors(values, resolve_categorical_cmap(cmap))
             expr = ["match", ["get", column]]
             for category, color in zip(categories, colors):
                 expr.extend([_native(category), color])
-            expr.append("#cccccc")  # fallback colour for values outside the known categories
+            expr.append(MISSING_COLOR)  # fallback for values outside the known categories (shared by all tiers)
             self.last_breaks = [_native(c) for c in categories]
             return expr
 

--- a/tests/test_quickplot.py
+++ b/tests/test_quickplot.py
@@ -48,6 +48,42 @@ def test_quickmap_choropleth_polygons():
     assert m.ax.collections
 
 
+def _zoned_polygons():
+    """Buffered-point polygons carrying a nominal 'zone' column (three unordered classes)."""
+    from pyramids.feature import FeatureCollection
+
+    fc = FeatureCollection.read_file("tests/data/points.geojson")
+    fc["geometry"] = fc.geometry.buffer(500.0)
+    fc["zone"] = [["urban", "rural", "park"][i % 3] for i in range(len(fc))]
+    return fc
+
+
+def test_quickmap_categorical_has_no_spurious_colorbar():
+    """A categorical quickmap keys itself with a swatch legend, so no meaningless numeric colorbar is added.
+
+    The mappable carries integer class codes; a colorbar over them would read -0.5, 0.5, 1.5 next to the swatch
+    legend — the one-call api must skip it (M2), leaving a single axes.
+    """
+    fc = _zoned_polygons()
+    m = qp.quickmap(fc, crs=fc.epsg, column="zone", scheme="categorical")
+    assert len(m.fig.axes) == 1, "categorical map must not gain a colorbar axes on top of its swatch legend"
+    assert m.layers[-1][0].category_legend is not None, "the swatch legend is still the key"
+
+
+def test_module_choropleth_categorical_has_no_spurious_colorbar():
+    """The module-level choropleth() helper (the _finish path) also skips the colorbar for a categorical fill."""
+    fc = _zoned_polygons()
+    m = qp.choropleth(fc, crs=fc.epsg, column="zone", scheme="categorical")
+    assert len(m.fig.axes) == 1, "the _finish path must skip the colorbar for a categorical fill too"
+
+
+def test_quickmap_graduated_still_gets_its_colorbar():
+    """A non-categorical fill must still receive its aggregated colorbar (the M2 guard must not over-fire)."""
+    fc = _zoned_polygons()
+    m = qp.quickmap(fc, crs=fc.epsg, column="fid", scheme="quantiles", k=3)
+    assert len(m.fig.axes) == 2, "a graduated numeric fill still carries a colorbar"
+
+
 def test_quickmap_rejects_unsupported_type():
     """quickmap raises on an input type it cannot draw."""
     with pytest.raises(TypeError, match="cannot draw"):

--- a/tests/test_quickplot.py
+++ b/tests/test_quickplot.py
@@ -84,6 +84,11 @@ def test_quickmap_graduated_still_gets_its_colorbar():
     assert len(m.fig.axes) == 2, "a graduated numeric fill still carries a colorbar"
 
 
+def test_last_layer_is_categorical_on_empty_scene():
+    """The categorical predicate is False on a scene with no layers (self-safe when called directly)."""
+    assert qp._last_layer_is_categorical(Map(crs=4326)) is False, "an empty scene has no categorical layer"
+
+
 def test_quickmap_rejects_unsupported_type():
     """quickmap raises on an input type it cannot draw."""
     with pytest.raises(TypeError, match="cannot draw"):

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -64,6 +64,21 @@ def test_categorical_cmap_agrees_with_the_sibling_tiers(zoned, cmap):
     assert rendered_colors(pc, len(expected)) == [c.lower() for c in expected]
 
 
+def test_categorical_cmap_cycles_in_step_with_the_sibling_tiers(polygons):
+    """Past the palette length the static render must cycle the cmap the same way the sibling helper does.
+
+    `Accent` has 8 entries; giving every polygon a distinct class (10 of them) wraps classes 8 and 9 back to the
+    palette start, and static (via cleopatra) and web/interactive (via `categorical_colors`) must land on the
+    same colour for the wrapped classes too, not just the first eight.
+    """
+    fc = polygons.copy()
+    fc["zone"] = [f"c{i:02d}" for i in range(len(fc))]
+    pc = Map(crs=fc.epsg).choropleth(fc, column="zone", scheme="categorical", cmap="Accent")
+    categories, expected = categorical_colors(fc["zone"], "Accent")
+    assert len(categories) > 8, "the fixture must span more classes than the 8-colour palette to force a cycle"
+    assert rendered_colors(pc, len(categories)) == [c.lower() for c in expected], "static cycles in step"
+
+
 def test_categorical_missing_values_are_drawn_neutral(polygons):
     """A missing category is drawn neutral, not invisible — matching the web/interactive tiers (M4).
 

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -60,6 +60,20 @@ def test_categorical_cmap_agrees_with_the_sibling_tiers(zoned, cmap):
     assert rendered_colors(pc, len(expected)) == [c.lower() for c in expected]
 
 
+@pytest.mark.parametrize("spelling", ["categorical", "Categorical", "CATEGORICAL"])
+def test_categorical_scheme_spelling_is_case_insensitive(zoned, spelling):
+    """A case-variant ``scheme`` renders the same map, as it already does on the web tier (M3).
+
+    cleopatra dispatches on an exact ``== "categorical"``, so an unnormalized case variant used to set up a
+    categorical render here and then fall through to the continuous path there, dying in ``np.isfinite`` on a
+    string column.
+    """
+    m = Map(crs=zoned.epsg)
+    pc = m.choropleth(zoned, column="zone", scheme=spelling)
+    assert isinstance(pc.norm, BoundaryNorm)
+    assert [t.get_text() for t in m.layers[-1][0].category_legend.get_texts()] == ["park", "rural", "urban"]
+
+
 def test_categorical_cmap_coolwarm_r_is_a_known_upstream_divergence(zoned):
     """``cmap="coolwarm_r"`` is cleopatra's own sentinel, so the static tier swaps it where web honours it.
 

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -165,12 +165,18 @@ def test_choropleth_categorical_legend_can_be_suppressed(polygons):
 
 
 def test_graduated_choropleth_still_defers_its_key_to_the_scene(polygons):
-    """The categorical legend default must not leak into the graduated/continuous path (Scene owns that)."""
+    """The categorical legend default must not leak into the graduated/continuous path (Scene owns that).
+
+    The load-bearing assertion is on ``add_colorbar``: cleopatra resets ``category_legend`` to None on every
+    ``plot()`` and only sets it on the categorical branch, so asserting it is None on a graduated fill can never
+    fail — it would pass even if ``_polygon_layer`` wrongly defaulted ``add_colorbar=True`` for every scheme,
+    which is exactly the leak this test guards. Assert the default the glyph actually received instead.
+    """
     m = Map(crs=polygons.epsg)
     m.choropleth(polygons, column="fid", scheme="quantiles", k=3)
     glyph = m.layers[-1][0]
+    assert glyph.default_options["add_colorbar"] is False, "the Scene, not the glyph, owns the graduated key"
     assert glyph.cbar is None
-    assert getattr(glyph, "category_legend", None) is None
 
 
 def test_voronoi_scheme_is_discrete(points_fc):
@@ -195,3 +201,27 @@ def test_scheme_fisher_jenks(polygons):
     """The native Fisher-Jenks scheme is accepted (no mapclassify dependency)."""
     pc = Map(crs=polygons.epsg).choropleth(polygons, column="fid", scheme="fisher_jenks", k=3)
     assert isinstance(pc.norm, BoundaryNorm)
+
+
+@pytest.mark.parametrize(
+    "fixture,call",
+    [
+        ("points_fc", lambda m, fc: m.voronoi(fc, column="fid", scheme="categorical")),
+        ("polygons", lambda m, fc: m.cartogram(fc, scale="fid", column="fid", scheme="categorical")),
+        ("points_fc", lambda m, fc: m.quadtree(fc, column="fid", nmax=1, scheme="categorical")),
+    ],
+    ids=["voronoi", "cartogram", "quadtree"],
+)
+def test_sibling_polygon_methods_honour_categorical(request, fixture, call):
+    """voronoi/cartogram/quadtree inherit the categorical path through the shared helper (L4).
+
+    They accept ``scheme`` and pass values, so the ``add_colorbar`` categorical default reaches them too — the
+    swatch legend must be drawn (and no colorbar), exactly as for :meth:`choropleth`.
+    """
+    fc = request.getfixturevalue(fixture)
+    m = Map(crs=fc.epsg)
+    pc = call(m, fc)
+    glyph = m.layers[-1][0]
+    assert isinstance(pc.norm, BoundaryNorm)
+    assert glyph.cbar is None
+    assert glyph.category_legend is not None, "a categorical sibling fill must draw its own swatch legend"

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -203,6 +203,18 @@ def test_scheme_fisher_jenks(polygons):
     assert isinstance(pc.norm, BoundaryNorm)
 
 
+def test_categorical_scheme_on_outline_only_is_inert(polygons):
+    """An outline-only draw with scheme='categorical' (no values) skips the categorical mapping harmlessly.
+
+    ``shapes`` reaches ``_polygon_layer`` with ``values=None``, so the categorical value-mapping branch must be
+    a no-op — the outlines still draw and nothing crashes on the absent values.
+    """
+    m = Map(crs=polygons.epsg)
+    pc = m.shapes(polygons, scheme="categorical")
+    assert len(pc.get_paths()) == len(polygons), "outlines must still be drawn"
+    assert m.layers[-1][0].category_legend is None, "no values means no category legend"
+
+
 @pytest.mark.parametrize(
     "fixture,call",
     [

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -6,8 +6,9 @@ default (no ``scheme``) stays a continuous norm.
 """
 
 import pytest
-from matplotlib.colors import BoundaryNorm
+from matplotlib.colors import BoundaryNorm, to_hex
 
+from digitalearth._symbology import categorical_colors, resolve_categorical_cmap
 from digitalearth.scene import Map
 
 
@@ -25,6 +26,51 @@ def polygons(points_fc):
     fc = points_fc.copy()
     fc["geometry"] = fc.geometry.buffer(500.0)
     return fc
+
+
+@pytest.fixture
+def zoned(polygons):
+    """Polygon fixture carrying a nominal 'zone' column of three unordered classes."""
+    fc = polygons.copy()
+    labels = ["urban", "rural", "park"]
+    fc["zone"] = [labels[i % len(labels)] for i in range(len(fc))]
+    return fc
+
+
+def rendered_colors(mappable, count):
+    """Return the first ``count`` colours of a categorical mappable's colormap, as lower-case hex."""
+    cmap = mappable.get_cmap()
+    return [to_hex(cmap(i)) for i in range(count)]
+
+
+@pytest.mark.parametrize(
+    "cmap",
+    [None, "viridis", "Set2"],
+    ids=["default", "continuous-default", "qualitative"],
+)
+def test_categorical_cmap_agrees_with_the_sibling_tiers(zoned, cmap):
+    """Static must resolve ``cmap`` through the same sentinel as web/interactive, else one cmap means two maps.
+
+    cleopatra swaps its *own* continuous default (``coolwarm_r``) for a qualitative map, while the sibling tiers
+    swap ``viridis`` — so without a shared sentinel ``cmap="viridis"`` renders viridis here and tab10 there (M1).
+    """
+    opts = {} if cmap is None else {"cmap": cmap}
+    pc = Map(crs=zoned.epsg).choropleth(zoned, column="zone", scheme="categorical", **opts)
+    _, expected = categorical_colors(zoned["zone"], resolve_categorical_cmap(cmap))
+    assert rendered_colors(pc, len(expected)) == [c.lower() for c in expected]
+
+
+def test_categorical_cmap_coolwarm_r_is_a_known_upstream_divergence(zoned):
+    """``cmap="coolwarm_r"`` is cleopatra's own sentinel, so the static tier swaps it where web honours it.
+
+    Pins the one divergence that cannot be resolved from this side (it needs an upstream change), so a future
+    cleopatra release that changes the rule fails here loudly instead of drifting silently.
+    """
+    pc = Map(crs=zoned.epsg).choropleth(zoned, column="zone", scheme="categorical", cmap="coolwarm_r")
+    _, web_colors = categorical_colors(zoned["zone"], resolve_categorical_cmap("coolwarm_r"))
+    _, tab10 = categorical_colors(zoned["zone"], "tab10")
+    assert rendered_colors(pc, 3) == [c.lower() for c in tab10], "static swaps cleopatra's own default sentinel"
+    assert [c.lower() for c in web_colors] != [c.lower() for c in tab10], "web honours it — the divergence"
 
 
 def test_choropleth_scheme_is_discrete(polygons):

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -46,14 +46,17 @@ def rendered_colors(mappable, count):
 
 @pytest.mark.parametrize(
     "cmap",
-    [None, "viridis", "Set2"],
-    ids=["default", "continuous-default", "qualitative"],
+    [None, "viridis", "Set2", "coolwarm", "RdBu"],
+    ids=["default", "continuous-default", "qualitative", "linseg-coolwarm", "linseg-rdbu"],
 )
 def test_categorical_cmap_agrees_with_the_sibling_tiers(zoned, cmap):
     """Static must resolve ``cmap`` through the same sentinel as web/interactive, else one cmap means two maps.
 
     cleopatra swaps its *own* continuous default (``coolwarm_r``) for a qualitative map, while the sibling tiers
     swap ``viridis`` — so without a shared sentinel ``cmap="viridis"`` renders viridis here and tab10 there (M1).
+    The honoured ``LinearSegmentedColormap`` cases (``coolwarm``/``RdBu``, not the ``_r`` sentinel) guard the
+    other half: both tiers must sample it at the same n evenly-spaced points, not the first-n near-identical
+    LUT entries.
     """
     opts = {} if cmap is None else {"cmap": cmap}
     pc = Map(crs=zoned.epsg).choropleth(zoned, column="zone", scheme="categorical", **opts)

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -5,6 +5,7 @@
 default (no ``scheme``) stays a continuous norm.
 """
 
+import pandas as pd
 import pytest
 from matplotlib.colors import BoundaryNorm, to_hex
 
@@ -77,6 +78,25 @@ def test_categorical_missing_values_are_drawn_neutral(polygons):
     assert to_hex(facecolors[0]) == MISSING_COLOR, "the null-attribute polygon must be drawn neutral"
     assert facecolors[0][3] > 0, "and must be visible at all (the default bad colour is fully transparent)"
     assert [t.get_text() for t in m.layers[-1][0].category_legend.get_texts()] == ["rural", "urban"]
+
+
+@pytest.mark.parametrize("dtype", ["object", "string"], ids=["object-None", "nullable-pdNA"])
+def test_categorical_nulls_never_become_a_category(polygons, dtype):
+    """The same logical data must render the same whether its nulls are ``None`` or ``pd.NA`` (M5).
+
+    A pandas nullable dtype spells its nulls ``pd.NA``, which survives cleopatra's ``is None``/float-NaN test
+    and becomes a real ``<NA>`` class — taking a palette colour and shifting every other category's.
+    """
+    fc = polygons.copy()
+    zones = [["urban", "rural"][i % 2] for i in range(len(fc))]
+    zones[0] = None
+    fc["zone"] = pd.array(zones, dtype=dtype)
+    m = Map(crs=fc.epsg)
+    pc = m.choropleth(fc, column="zone", scheme="categorical")
+    labels = [t.get_text() for t in m.layers[-1][0].category_legend.get_texts()]
+    assert labels == ["rural", "urban"], "a null must not become a category, whatever its dtype spelling"
+    pc.update_scalarmappable()
+    assert to_hex(pc.get_facecolors()[0]) == MISSING_COLOR, "the null row is missing data, not a class"
 
 
 @pytest.mark.parametrize("spelling", ["categorical", "Categorical", "CATEGORICAL"])

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -8,7 +8,7 @@ default (no ``scheme``) stays a continuous norm.
 import pytest
 from matplotlib.colors import BoundaryNorm, to_hex
 
-from digitalearth._symbology import categorical_colors, resolve_categorical_cmap
+from digitalearth._symbology import MISSING_COLOR, categorical_colors, resolve_categorical_cmap
 from digitalearth.scene import Map
 
 
@@ -58,6 +58,25 @@ def test_categorical_cmap_agrees_with_the_sibling_tiers(zoned, cmap):
     pc = Map(crs=zoned.epsg).choropleth(zoned, column="zone", scheme="categorical", **opts)
     _, expected = categorical_colors(zoned["zone"], resolve_categorical_cmap(cmap))
     assert rendered_colors(pc, len(expected)) == [c.lower() for c in expected]
+
+
+def test_categorical_missing_values_are_drawn_neutral(polygons):
+    """A missing category is drawn neutral, not invisible — matching the web/interactive tiers (M4).
+
+    cleopatra codes a missing category as ``NaN``, whose default "bad" colour is fully transparent, so the
+    feature would render as nothing and be indistinguishable from one that was never in the collection.
+    """
+    fc = polygons.copy()
+    zones = [["urban", "rural"][i % 2] for i in range(len(fc))]
+    zones[0] = None
+    fc["zone"] = zones
+    m = Map(crs=fc.epsg)
+    pc = m.choropleth(fc, column="zone", scheme="categorical")
+    pc.update_scalarmappable()  # resolve the value array into facecolors
+    facecolors = pc.get_facecolors()
+    assert to_hex(facecolors[0]) == MISSING_COLOR, "the null-attribute polygon must be drawn neutral"
+    assert facecolors[0][3] > 0, "and must be visible at all (the default bad colour is fully transparent)"
+    assert [t.get_text() for t in m.layers[-1][0].category_legend.get_texts()] == ["rural", "urban"]
 
 
 @pytest.mark.parametrize("spelling", ["categorical", "Categorical", "CATEGORICAL"])

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -35,10 +35,43 @@ def test_choropleth_scheme_is_discrete(polygons):
     assert not isinstance(continuous.norm, BoundaryNorm)
 
 
-def test_choropleth_categorical_not_supported_in_static_tier(polygons):
-    """scheme='categorical' raises a clear, actionable error in the static tier (cleopatra gap, DC.8)."""
-    with pytest.raises(NotImplementedError, match="categorical"):
-        Map(crs=polygons.epsg).choropleth(polygons, column="fid", scheme="categorical")
+def test_choropleth_categorical_colors_each_distinct_value(polygons):
+    """scheme='categorical' gives every distinct value its own class code (cleopatra >=0.26, CAT-5)."""
+    fc = polygons.copy()
+    fc["zone"] = ["urban", "rural", "park"] * (len(fc) // 3) + ["urban"] * (len(fc) % 3)
+    pc = Map(crs=fc.epsg).choropleth(fc, column="zone", scheme="categorical")
+    assert isinstance(pc.norm, BoundaryNorm)
+    # the mappable carries integer class codes (one per distinct label), not the labels themselves
+    assert sorted(set(pc.get_array().tolist())) == [0.0, 1.0, 2.0]
+
+
+def test_choropleth_categorical_draws_a_swatch_legend(polygons):
+    """A categorical fill is keyed by a labelled swatch legend, not a colorbar (the codes would be opaque)."""
+    fc = polygons.copy()
+    fc["zone"] = ["urban", "rural"] * (len(fc) // 2) + ["urban"] * (len(fc) % 2)
+    m = Map(crs=fc.epsg)
+    m.choropleth(fc, column="zone", scheme="categorical")
+    glyph = m.layers[-1][0]
+    assert glyph.cbar is None
+    assert [t.get_text() for t in glyph.category_legend.get_texts()] == ["rural", "urban"]
+
+
+def test_choropleth_categorical_legend_can_be_suppressed(polygons):
+    """An explicit add_colorbar=False keeps the glyph from drawing its own key (the Scene takes over)."""
+    fc = polygons.copy()
+    fc["zone"] = ["urban", "rural"] * (len(fc) // 2) + ["urban"] * (len(fc) % 2)
+    m = Map(crs=fc.epsg)
+    m.choropleth(fc, column="zone", scheme="categorical", add_colorbar=False)
+    assert m.layers[-1][0].category_legend is None
+
+
+def test_graduated_choropleth_still_defers_its_key_to_the_scene(polygons):
+    """The categorical legend default must not leak into the graduated/continuous path (Scene owns that)."""
+    m = Map(crs=polygons.epsg)
+    m.choropleth(polygons, column="fid", scheme="quantiles", k=3)
+    glyph = m.layers[-1][0]
+    assert glyph.cbar is None
+    assert getattr(glyph, "category_legend", None) is None
 
 
 def test_voronoi_scheme_is_discrete(points_fc):

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -94,6 +94,22 @@ def test_drops_pandas_nullable_na():
 
 
 @pytest.mark.parametrize(
+    "cmap",
+    ["tab10", "Set2", "coolwarm", "RdBu", "jet", "viridis"],
+    ids=["listed-tab10", "listed-set2", "linseg-coolwarm", "linseg-rdbu", "linseg-jet", "listed-viridis"],
+)
+def test_matches_cleopatra_categorize_across_colormap_kinds(cmap):
+    """Colours match cleopatra for both colormap kinds — a LinearSegmentedColormap must sample evenly, not
+    collapse to the first-n near-identical LUT entries (the cross-tier crack this closes)."""
+    from cleopatra.styles import categorize
+
+    values = ["a", "b", "c"]
+    _, ours = categorical_colors(values, cmap)
+    _, upstream = categorize(np.asarray(values, dtype=object), cmap)
+    assert [c.lower() for c in ours] == [c.lower() for c in upstream], f"colours must match cleopatra for {cmap}"
+
+
+@pytest.mark.parametrize(
     "values",
     [
         ["urban", "rural", "park", "urban"],  # strings, sortable

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -1,8 +1,47 @@
 """Tests for digitalearth._symbology — categorical (distinct-value → colour) mapping (DC.8)."""
 import numpy as np
+import pandas as pd
 import pytest
 
-from digitalearth._symbology import categorical_colors, resolve_categorical_cmap
+from digitalearth._symbology import (
+    categorical_colors,
+    is_null,
+    nulls_to_none,
+    resolve_categorical_cmap,
+)
+
+
+class TestIsNull:
+    """Tests for is_null — the scalar-null predicate shared by every tier's categorical path."""
+
+    @pytest.mark.parametrize("value", [None, np.nan, pd.NA, pd.NaT, float("nan")])
+    def test_missing_values_are_null(self, value):
+        """Every spelling of a missing scalar reads as null."""
+        assert is_null(value) is True, f"{value!r} should be null"
+
+    @pytest.mark.parametrize("value", ["urban", 0, False, 1.5, "", np.int64(3)])
+    def test_real_values_are_not_null(self, value):
+        """A genuine category — including falsy 0/False/'' — is never null."""
+        assert is_null(value) is False, f"{value!r} should not be null"
+
+    @pytest.mark.parametrize("value", [[1, 2], np.array([1, 2])])
+    def test_non_scalar_is_not_null(self, value):
+        """A list-like value whose `pd.isna` is elementwise flows on as a (non-null) value, not a null."""
+        assert is_null(value) is False, f"non-scalar {value!r} should flow on as a value"
+
+
+class TestNullsToNone:
+    """Tests for nulls_to_none — normalizing a column's nulls to the one spelling cleopatra recognises."""
+
+    def test_pd_na_becomes_none(self):
+        """A pandas nullable-dtype null is rewritten to None so cleopatra drops it."""
+        out = nulls_to_none(pd.array(["urban", pd.NA, "rural"], dtype="string"))
+        assert out.tolist() == ["urban", None, "rural"], f"pd.NA must normalize to None, got {out.tolist()}"
+
+    def test_no_nulls_is_unchanged(self):
+        """A column with no nulls comes back with its values intact."""
+        out = nulls_to_none(np.array(["a", "b"], dtype=object))
+        assert out.tolist() == ["a", "b"], f"non-null values must survive untouched, got {out.tolist()}"
 
 
 def test_distinct_categories_get_distinct_colors():

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -43,6 +43,16 @@ class TestNullsToNone:
         out = nulls_to_none(np.array(["a", "b"], dtype=object))
         assert out.tolist() == ["a", "b"], f"non-null values must survive untouched, got {out.tolist()}"
 
+    def test_two_dimensional_input(self):
+        """A 2-D array normalizes nulls elementwise and keeps its shape."""
+        out = nulls_to_none(np.array([["a", None], ["b", "c"]], dtype=object))
+        assert out.tolist() == [["a", None], ["b", "c"]], f"2-D nulls must normalize in place, got {out.tolist()}"
+
+    def test_list_cell_falls_back_and_is_kept(self):
+        """A list-like cell (where vectorized `pd.isna` is non-elementwise) flows on as a value, not a null."""
+        out = nulls_to_none(np.array(["a", [1, 2], None], dtype=object))
+        assert out[0] == "a" and out[1] == [1, 2] and out[2] is None, f"list cell must survive, got {out.tolist()}"
+
 
 def test_distinct_categories_get_distinct_colors():
     cats, colors = categorical_colors(["a", "b", "a", "c"])

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -43,6 +43,17 @@ def test_resolve_categorical_cmap_swaps_continuous_default():
     assert resolve_categorical_cmap("Set2") == "Set2", "an explicit cmap must be honoured"
 
 
+def test_drops_pandas_nullable_na():
+    """`pd.NA`/`pd.NaT` are nulls, not categories — a nullable dtype must classify like an object one (M5)."""
+    import pandas as pd
+
+    cats, colors = categorical_colors(pd.array(["urban", pd.NA, "rural"], dtype="string"))
+    assert cats == ["rural", "urban"], f"pd.NA must not become a category, got {cats}"
+    assert len(colors) == 2
+    object_cats, _ = categorical_colors(["urban", None, "rural"])
+    assert cats == object_cats, "the same logical data must classify identically across dtypes"
+
+
 @pytest.mark.parametrize(
     "values",
     [

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -48,8 +48,8 @@ class TestNullsToNone:
         out = nulls_to_none(np.array([["a", None], ["b", "c"]], dtype=object))
         assert out.tolist() == [["a", None], ["b", "c"]], f"2-D nulls must normalize in place, got {out.tolist()}"
 
-    def test_list_cell_falls_back_and_is_kept(self):
-        """A list-like cell (where vectorized `pd.isna` is non-elementwise) flows on as a value, not a null."""
+    def test_list_cell_is_kept_as_a_value(self):
+        """A list-like cell reads as a non-null value (vectorized `pd.isna` stays elementwise), only None drops."""
         out = nulls_to_none(np.array(["a", [1, 2], None], dtype=object))
         assert out[0] == "a" and out[1] == [1, 2] and out[2] is None, f"list cell must survive, got {out.tolist()}"
 

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -41,3 +41,26 @@ def test_resolve_categorical_cmap_swaps_continuous_default():
     """The continuous default is swapped for a qualitative map; an explicit cmap is honoured (N1)."""
     assert resolve_categorical_cmap("viridis") == "tab10", "continuous default → qualitative default"
     assert resolve_categorical_cmap("Set2") == "Set2", "an explicit cmap must be honoured"
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        ["urban", "rural", "park", "urban"],  # strings, sortable
+        [3, 1, 2, 1],  # numbers, sortable
+        ["b", None, "a", float("nan")],  # nulls dropped
+    ],
+    ids=["strings", "numbers", "with-nulls"],
+)
+def test_matches_cleopatra_categorize(values):
+    """This helper must agree with cleopatra's ``categorize`` — same classes, same colours (CAT-5).
+
+    The static tier maps categories via cleopatra while the web/interactive tiers use this helper, so the two
+    must derive an identical category→colour table or the same data would render different colours per tier.
+    """
+    from cleopatra.styles import categorize
+
+    ours_cats, ours_colors = categorical_colors(values)
+    upstream_cats, upstream_colors = categorize(np.asarray(values, dtype=object))
+    assert list(ours_cats) == list(upstream_cats), "categories must match cleopatra's (order and content)"
+    assert [c.lower() for c in ours_colors] == [c.lower() for c in upstream_colors], "colours must match"


### PR DESCRIPTION
# Description

Wires the **static** tier's `Map.choropleth(scheme="categorical")` to cleopatra's distinct-value categorical
path and **deletes the `NotImplementedError` guard** that stood in for it. Categorical symbology (one colour per
distinct value — a land-use class, a region name) now works in **all three tiers** (static, interactive, web) off
an identical classification.

The guard existed because cleopatra's `PolygonGlyph` could only colour by a continuous/graduated scale. That gap
was filed upstream as `cleopatra#204`, implemented there, and **released in cleopatra 0.26.0** — so this PR bumps
the floor and consumes it, rather than re-implementing the colour work locally (cleopatra owns generic
matplotlib/colour work).

**Dependency:** `cleopatra >=0.25.0 → >=0.26.0` (+ `pixi.lock` re-solved).

Closes:

- Closes #123 — enable categorical symbology in the static tier (the headline feature)
- Closes #124 — render one categorical cmap identically across all three tiers
- Closes #125 — handle missing categorical values consistently across tiers
- Closes #126 — skip the spurious colorbar on a categorical one-call map

Beyond deleting the guard, two things needed real wiring:

- **The categorical legend.** cleopatra only draws its category legend inside `if draw_colorbar:`, and
  `_polygon_layer` sets `add_colorbar=False` because the Scene owns the aggregated colorbar — so deleting the
  guard alone would have rendered a silently **unlabeled** map. The Scene's colorbar cannot stand in for it: a
  categorical fill feeds the mappable opaque integer class codes, so a colorbar over them reads `0, 1, 2 …`
  instead of the category labels. `add_colorbar` now defaults to `True` for a categorical fill so the glyph
  draws its own swatch legend; an explicit `add_colorbar=False` still hands the key back to the Scene. This
  lives in the shared `_polygon_layer`, so `voronoi`/`cartogram`/`quadtree` get it too.
- **Nominal (non-numeric) columns.** `choropleth`'s docstring said "numeric column", but unordered labels are the
  whole point of a categorical scheme. Verified the existing pipeline already carries them: `_finite_polygons`
  masks on *vertex* coordinates and index-filters the values, so a string column survives intact.

`_symbology` is narrowed to the web/interactive tiers, where it is still required: MapLibre needs a literal
`["match", …]` colour expression and GeoViews a `{value: colour}` dict — neither can consume cleopatra's
matplotlib `ListedColormap` + `BoundaryNorm`. Its module docstring previously claimed "no cleopatra equivalent
exists yet", which 0.26.0 makes false; it now states the real reason it survives. A new test pins it to derive
the **same** categories and colours as `cleopatra.styles.categorize`, so the same data cannot silently render
different colours per tier after an upstream bump.

### Note on the cleopatra 0.26.0 upgrade

0.26.0 also carries a **breaking** `ArrayGlyph.plot()`/`animate()` kwarg change (`refactor(array_glyph)!`,
cleopatra#207/#208: `point_color` / `point_size` / `pid_color` / `pid_size` / `animate()`'s `label_color` are no
longer explicit parameters; keyword calls still work behind a `DeprecationWarning`, positional calls break).
**digitalearth is unaffected** — it never passes those names to `ArrayGlyph` and never calls `plot()`/`animate()`
positionally. Confirmed by running the full suite on 0.26.0 *before* any source change (a clean **663 passed**
baseline), so nothing in this PR masks an upgrade break.

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Every tier suite is green on cleopatra 0.26.0 (worktree env, Python 3.13, Windows 11, `MPLBACKEND=Agg`):

- [x] `pixi run -e dev pytest` → **666 passed, 99 skipped** (baseline before the change on 0.26.0: 663 passed —
      the delta is this PR's new tests, minus the deleted guard test)
- [x] `pixi run -e web pytest tests/test_web_*.py` → **110 passed, 1 skipped**
- [x] `pixi run -e interactive pytest tests/test_interactive_*.py` → **248 passed, 1 skipped**
- [x] `pixi run -e viz3d pytest tests/test_*3d.py` → **60 passed**

New/changed tests:

- `tests/test_scheme.py` — replaces the old `NotImplementedError` assertion with the behaviour that supersedes
  it: distinct values get distinct class codes under a `BoundaryNorm`; the fill is keyed by a **labelled swatch
  legend** and no colorbar (`cbar is None`); `add_colorbar=False` suppresses the legend; and a regression guard
  that the categorical legend default does **not** leak into the graduated/continuous path (the Scene still owns
  that key).
- `tests/test_symbology.py` — the cross-tier invariant that `_symbology.categorical_colors` and
  `cleopatra.styles.categorize` agree on categories *and* colours (strings / numbers / with-nulls).

The two `choropleth` docstring examples were executed manually via `doctest` (13 assertions, 0 failures) — the
suite does not collect doctests (`testpaths = ["tests"]`), so they are not covered by CI.

# Checklist:

- [ ] updated version number in setup.py/pyproject.toml — N/A (the package version is bumped by commitizen in
      CI; this PR bumps a dependency floor, not the package version)
- [x] updated environment.yml and the lock file — `pixi.lock` re-solved across all environments
- [ ] added changes to History.rst — N/A (the changelog is generated by commitizen in CI)
- [ ] updated the latest version in README file — N/A
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

