### PR TITLE
feat(scene): animate RGB/HSV composites on one frozen stretch

### DIFF
--- a/src/digitalearth/scene/maps/animation.py
+++ b/src/digitalearth/scene/maps/animation.py
@@ -5,6 +5,7 @@ Drives per-frame redraws on the shared axes as a matplotlib ``FuncAnimation``, w
 """
 from typing import Any, List, Optional, Sequence, Tuple
 
+import numpy as np
 from matplotlib.animation import FuncAnimation
 from matplotlib.cm import ScalarMappable
 from matplotlib.colors import Normalize
@@ -12,12 +13,19 @@ from matplotlib.colors import Normalize
 from digitalearth._arrays import finite, read_masked_band
 from digitalearth.animation import save_animation
 from digitalearth.scene import projections
+from digitalearth.scene.maps.raster import channel_limits
+from digitalearth.sources import get_stack
 
 #: Cap on how many stack frames are scanned to derive a shared animation colour scale (L2).
 _CLIM_SCAN_CAP = 24
 
+#: Composite render methods accepted as an animation ``kind``. They paint colour directly rather than
+#: mapping one band through a colormap, so they take the frozen-stretch path below instead of a shared
+#: ``vmin``/``vmax``, and they have no mappable a colorbar could key to.
+_COMPOSITE_KINDS = ("rgb_composite", "hsv_composite")
+
 #: Field-render methods accepted as the ``kind`` of an animation frame (validated up front, N1).
-_ANIMATION_KINDS = ("imshow", "contourf", "contour", "pcolormesh", "block")
+_ANIMATION_KINDS = ("imshow", "contourf", "contour", "pcolormesh", "block") + _COMPOSITE_KINDS
 
 
 class AnimationMixin:
@@ -154,13 +162,55 @@ class AnimationMixin:
             cbar.set_label(label)
         return cbar
 
-    def _prime_animation(self, datasets: Sequence[Any], opts: dict, *, colorbar: bool,
+    @staticmethod
+    def _resolve_composite_stretch(datasets: Sequence[Any], opts: dict) -> None:
+        """Freeze one per-channel contrast stretch into ``opts`` for a composite animation.
+
+        The composite renderers stretch each channel between its own 2-98 percentiles. Left per frame that
+        gives every frame its own black and white point, so a scene that never changes still pulses in
+        brightness — the artefact a viewer reads as the data changing. Scanning the stack once and pinning
+        ``stretch_limits`` keeps all frames on one scale, the composite counterpart of
+        :meth:`_resolve_animation_clim`.
+
+        An explicit ``stretch_limits`` from the caller is honoured untouched. As with the clim scan, at most
+        :data:`_CLIM_SCAN_CAP` evenly-spaced frames are sampled so the cost does not grow with the stack.
+        """
+        if opts.get("stretch_limits") is not None:
+            return
+        bands = tuple(opts.get("bands", (1, 2, 3)))
+        mask = opts.get("mask_nodata", True)
+        seq = list(datasets)
+        stride = max(1, len(seq) // _CLIM_SCAN_CAP)
+        sampled = [get_stack(ds, bands, mask=mask) for ds in seq[::stride]]
+        # Percentiles over the concatenated frames, so the bounds describe the series and not whichever
+        # frame happened to be sampled first.
+        opts["stretch_limits"] = channel_limits(np.concatenate(sampled, axis=0))
+
+    def _prime_animation(self, datasets: Sequence[Any], opts: dict, *, kind: str, colorbar: bool,
                          cbar_label: Optional[str]) -> None:
         """Resolve one shared colour scale into ``opts`` and, if asked, add the single static colorbar.
 
-        The setup shared by :meth:`animate` and :meth:`rotate`: fill a missing ``vmin``/``vmax`` once from the
-        stack so colours don't flicker between frames, then optionally draw one persistent colorbar.
+        The setup shared by :meth:`animate` and :meth:`rotate`: fix the colour treatment once across the
+        whole stack so it does not flicker between frames, then optionally draw one persistent colorbar.
+
+        Which treatment depends on ``kind``. A scalar field gets a shared ``vmin``/``vmax``
+        (:meth:`_resolve_animation_clim`); a composite paints colour directly, so it gets a frozen
+        per-channel stretch instead (:meth:`_resolve_composite_stretch`) and has no mappable to key a
+        colorbar to.
+
+        Raises:
+            ValueError: if ``colorbar=True`` is asked for on a composite animation, which has no single
+                mappable a colorbar could describe.
         """
+        if kind in _COMPOSITE_KINDS:
+            if colorbar:
+                raise ValueError(
+                    f"colorbar=True is not meaningful for kind={kind!r}: a composite paints colour from "
+                    "several bands at once, so there is no single value scale to draw. Drop colorbar=, or "
+                    "animate a single band with kind='imshow' to get one."
+                )
+            self._resolve_composite_stretch(datasets, opts)
+            return
         self._resolve_animation_clim(datasets, opts)
         if colorbar:
             self._animation_colorbar(opts, cbar_label)
@@ -194,30 +244,35 @@ class AnimationMixin:
         frame, so every frame gets the boundary, graticule, and limb-clipping for free. The returned
         animation is lazy: call ``anim.save("out.gif", writer=PillowWriter(fps=...))`` or display it.
 
-        All frames share **one colour scale**: ``vmin``/``vmax`` from ``kwargs`` if given, else computed once
-        from the whole stack — so the colours (and the colorbar) do not flicker between frames.
+        All frames share **one colour treatment**, so the colours do not flicker between frames. For a
+        scalar ``kind`` that is a shared ``vmin``/``vmax`` — taken from ``kwargs`` if given, else computed
+        once from the whole stack. For a composite ``kind`` it is a shared per-channel contrast stretch,
+        computed once over the stack (or supplied as ``stretch_limits``); a composite has no single value
+        scale, so ``colorbar=True`` is rejected rather than silently drawing a misleading one.
 
         Args:
             stack: An ordered, indexable collection of pyramids ``Dataset`` frames (e.g. a list, or a
                 ``DatasetCollection`` datacube) — one raster per animation frame.
-            kind: The field method used to draw each frame — one of ``"imshow"`` / ``"contourf"`` /
-                ``"contour"`` / ``"pcolormesh"`` / ``"block"``.
+            kind: The method used to draw each frame — a scalar field renderer (``"imshow"`` /
+                ``"contourf"`` / ``"contour"`` / ``"pcolormesh"`` / ``"block"``) or a colour composite
+                (``"rgb_composite"`` / ``"hsv_composite"``), which takes ``bands=`` in ``**kwargs``.
             fps: Frames per second (sets the inter-frame interval).
             titles: Optional per-frame titles; must match the stack length when given.
             ocean: When True, fill the ocean disc behind each frame (globe maps only).
             coastlines: When True, overlay coastlines each frame (best-effort; ignored if unreachable).
             colorbar: When True, add one static colorbar (drawn once, not per frame) using the shared
-                colour scale.
+                colour scale. Not available for a composite ``kind``.
             cbar_label: Optional label for the colorbar.
-            **kwargs: Forwarded to the ``kind`` method (e.g. ``cmap``, ``vmin``, ``vmax``).
+            **kwargs: Forwarded to the ``kind`` method (e.g. ``cmap``, ``vmin``, ``vmax`` for a scalar
+                field; ``bands``, ``stretch_limits`` for a composite).
 
         Returns:
             A :class:`matplotlib.animation.FuncAnimation` over ``len(stack)`` frames (also kept on
             ``self._animation`` so it is not garbage-collected before you save/display it).
 
         Raises:
-            ValueError: if ``kind`` is not a known field renderer, ``stack`` is empty, or ``titles`` is given
-                with a mismatched length.
+            ValueError: if ``kind`` is not a known renderer, ``stack`` is empty, ``titles`` is given with a
+                mismatched length, or ``colorbar=True`` is asked for on a composite ``kind``.
         """
         if kind not in _ANIMATION_KINDS:
             raise ValueError(f"unknown animation kind {kind!r}; choose one of {_ANIMATION_KINDS}")
@@ -226,7 +281,7 @@ class AnimationMixin:
             raise ValueError("animate got an empty stack (nothing to animate)")
         if titles is not None and len(titles) != len(frames):
             raise ValueError(f"titles length ({len(titles)}) must match the stack length ({len(frames)})")
-        self._prime_animation(frames, kwargs, colorbar=colorbar, cbar_label=cbar_label)
+        self._prime_animation(frames, kwargs, kind=kind, colorbar=colorbar, cbar_label=cbar_label)
 
         def draw_one(i: int) -> None:
             title = titles[i] if titles is not None else None
@@ -273,7 +328,7 @@ class AnimationMixin:
         if kind not in _ANIMATION_KINDS:
             raise ValueError(f"unknown animation kind {kind!r}; choose one of {_ANIMATION_KINDS}")
         self.globe = True
-        self._prime_animation([dataset], kwargs, colorbar=colorbar, cbar_label=cbar_label)
+        self._prime_animation([dataset], kwargs, kind=kind, colorbar=colorbar, cbar_label=cbar_label)
         lons = [lon0 + k * (360.0 / n_frames) for k in range(n_frames)]
 
         def draw_one(i: int) -> None:

--- a/src/digitalearth/scene/maps/animation.py
+++ b/src/digitalearth/scene/maps/animation.py
@@ -251,8 +251,9 @@ class AnimationMixin:
         scale, so ``colorbar=True`` is rejected rather than silently drawing a misleading one.
 
         Args:
-            stack: An ordered, indexable collection of pyramids ``Dataset`` frames (e.g. a list, or a
-                ``DatasetCollection`` datacube) — one raster per animation frame.
+            stack: An ordered collection of pyramids ``Dataset`` frames — one raster per animation frame.
+                A plain list, or a ``DatasetCollection`` datacube (its ``.datasets`` are used, since the
+                collection itself iterates to arrays rather than to its members).
             kind: The method used to draw each frame — a scalar field renderer (``"imshow"`` /
                 ``"contourf"`` / ``"contour"`` / ``"pcolormesh"`` / ``"block"``) or a colour composite
                 (``"rgb_composite"`` / ``"hsv_composite"``), which takes ``bands=`` in ``**kwargs``.
@@ -276,7 +277,10 @@ class AnimationMixin:
         """
         if kind not in _ANIMATION_KINDS:
             raise ValueError(f"unknown animation kind {kind!r}; choose one of {_ANIMATION_KINDS}")
-        frames = list(stack)
+        # A DatasetCollection iterates to numpy arrays, not to its members, so unwrap `.datasets` before
+        # listing — otherwise the documented datacube input reaches the renderers as bare arrays and dies
+        # on the first `.read_array` (#154).
+        frames = list(getattr(stack, "datasets", stack))
         if not frames:
             raise ValueError("animate got an empty stack (nothing to animate)")
         if titles is not None and len(titles) != len(frames):

--- a/src/digitalearth/scene/maps/animation.py
+++ b/src/digitalearth/scene/maps/animation.py
@@ -120,12 +120,20 @@ class AnimationMixin:
         return save_animation(anim, path, fps=rate, gif=gif, **kwargs)
 
     @staticmethod
-    def _stack_clim(datasets: Sequence[Any]) -> Tuple[float, float]:
-        """Return the ``(min, max)`` of the first band across ``datasets``, ignoring nodata/non-finite."""
+    def _stack_clim(datasets: Sequence[Any], band: int = 1) -> Tuple[float, float]:
+        """Return the ``(min, max)`` of ``band`` across ``datasets``, ignoring nodata/non-finite.
+
+        Args:
+            datasets: The frames to scan.
+            band: 1-based band index — the one being animated, so the scale matches what is drawn.
+
+        Returns:
+            The ``(low, high)`` bounds, or ``(0.0, 1.0)`` when every frame is empty.
+        """
         lows: List[float] = []
         highs: List[float] = []
         for ds in datasets:
-            arr = finite(read_masked_band(ds, band=1))
+            arr = finite(read_masked_band(ds, band=band))
             if arr.size:
                 lows.append(float(arr.min()))
                 highs.append(float(arr.max()))
@@ -144,7 +152,9 @@ class AnimationMixin:
         if vmin is None or vmax is None:
             seq = list(datasets)
             stride = max(1, len(seq) // _CLIM_SCAN_CAP)  # cap the scan to ~_CLIM_SCAN_CAP frames
-            lo, hi = self._stack_clim(seq[::stride])
+            # Scan the band that will actually be drawn: `band` is forwarded to the renderer, so scanning
+            # band 1 regardless would scale every other band against the wrong range (#155).
+            lo, hi = self._stack_clim(seq[::stride], band=opts.get("band", 1))
             opts["vmin"] = lo if vmin is None else vmin
             opts["vmax"] = hi if vmax is None else vmax
 

--- a/src/digitalearth/scene/maps/raster.py
+++ b/src/digitalearth/scene/maps/raster.py
@@ -3,7 +3,7 @@
 Wires a pyramids ``Dataset`` (reprojected to the display CRS by the base) into cleopatra ``ArrayGlyph`` field
 renders, plus the RGB/HSV composites and the ensemble spaghetti overlay.
 """
-from typing import Any, List, Optional, Sequence
+from typing import Any, List, Optional, Sequence, Tuple
 
 import numpy as np
 from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph, RgbBands
@@ -13,16 +13,55 @@ from digitalearth.autostyle import auto_style
 from digitalearth.preprocess import add_cyclic_column
 from digitalearth.sources import get_stack
 
+#: Percentile pair the composite contrast stretch clips to, per channel.
+STRETCH_PERCENTILES = (2, 98)
 
-def _stretch_to_unit(stack: np.ndarray) -> np.ndarray:
-    """Per-channel 2-98 percentile contrast stretch of an ``(rows, cols, n)`` stack into ``[0, 1]``."""
-    out = np.empty(stack.shape, dtype="float64")
+
+def channel_limits(stack: np.ndarray) -> List[Tuple[float, float]]:
+    """Per-channel ``(low, high)`` stretch bounds of an ``(rows, cols, n)`` stack.
+
+    Split out of :func:`_stretch_to_unit` so a caller can compute the bounds over a whole *series* of
+    rasters and then hold them fixed — see :meth:`~digitalearth.scene.maps.animation.AnimationMixin.animate`,
+    where per-frame bounds would make a composite time-lapse pulse in brightness.
+
+    Args:
+        stack: A band-last ``(rows, cols, n)`` array; nodata cells are expected to be ``NaN``.
+
+    Returns:
+        One ``(low, high)`` pair per channel, with ``high`` nudged above ``low`` for a flat channel so the
+        stretch cannot divide by zero.
+    """
+    limits: List[Tuple[float, float]] = []
     for i in range(stack.shape[2]):
-        band = stack[..., i].astype("float64")
-        lo, hi = np.nanpercentile(band, [2, 98])
-        if hi <= lo:
-            hi = lo + 1.0
-        out[..., i] = np.clip((band - lo) / (hi - lo), 0.0, 1.0)
+        low, high = np.nanpercentile(stack[..., i].astype("float64"), STRETCH_PERCENTILES)
+        limits.append((float(low), float(high) if high > low else float(low) + 1.0))
+    return limits
+
+
+def _stretch_to_unit(stack: np.ndarray, limits: Optional[Sequence[Tuple[float, float]]] = None) -> np.ndarray:
+    """Per-channel contrast stretch of an ``(rows, cols, n)`` stack into ``[0, 1]``.
+
+    Args:
+        stack: A band-last ``(rows, cols, n)`` array.
+        limits: Optional precomputed per-channel ``(low, high)`` bounds. ``None`` (default) derives them
+            from this array alone via :func:`channel_limits`; passing bounds computed over a whole series
+            keeps every frame on one scale.
+
+    Returns:
+        The stretched stack, clipped into ``[0, 1]``.
+
+    Raises:
+        ValueError: if ``limits`` is given with a different number of pairs than the stack has channels.
+    """
+    if limits is None:
+        limits = channel_limits(stack)
+    elif len(limits) != stack.shape[2]:
+        raise ValueError(
+            f"limits has {len(limits)} channel bounds but the stack has {stack.shape[2]} channels"
+        )
+    out = np.empty(stack.shape, dtype="float64")
+    for i, (low, high) in enumerate(limits):
+        out[..., i] = np.clip((stack[..., i].astype("float64") - low) / (high - low), 0.0, 1.0)
     return out
 
 
@@ -142,7 +181,7 @@ class RasterMixin:
         return self._extent_of(ds.x, ds.y)
 
     def rgb_composite(self, dataset: Any, bands: Sequence[int] = (1, 2, 3), *, mask_nodata: bool = True,
-                      **opts) -> Any:
+                      stretch_limits: Optional[Sequence[Tuple[float, float]]] = None, **opts) -> Any:
         """Render three raster bands as a true/false-colour RGB image (``ArrayGlyph`` RGB path).
 
         Args:
@@ -151,6 +190,11 @@ class RasterMixin:
             mask_nodata: When ``True`` (default) each band's nodata cells are excluded from the 2-98
                 percentile stretch (and render transparent). Pass ``False`` for the raw values (the
                 pre-mask behaviour, where the nodata sentinel participates in the stretch).
+            stretch_limits: Optional per-channel ``(low, high)`` bounds for the contrast stretch, one pair
+                per band. ``None`` (default) derives them from this raster alone. Pass bounds computed over
+                a whole series (:func:`channel_limits`) to hold the stretch fixed across frames — which is
+                what :meth:`~digitalearth.scene.maps.animation.AnimationMixin.animate` does, so a composite
+                time-lapse does not pulse in brightness.
             **opts: Styling kwargs, filtered to ``ArrayGlyph``'s accepted options.
 
         Returns:
@@ -179,7 +223,7 @@ class RasterMixin:
         stack = get_stack(ds, bands, mask=mask_nodata)  # (rows, cols, n); nodata -> NaN unless mask_nodata=False
         # cleopatra's RgbBands path is band-FIRST: it does array[indices].transpose(1, 2, 0), so feed
         # (n, rows, cols) and let it transpose back to (rows, cols, n) for imshow.
-        band_first = np.moveaxis(_stretch_to_unit(stack), -1, 0)
+        band_first = np.moveaxis(_stretch_to_unit(stack, stretch_limits), -1, 0)
         plot_style = relocate_flat_style(opts)
         glyph = ArrayGlyph(
             band_first, rgb_bands=RgbBands(list(range(len(bands)))), extent=self._extent(ds),
@@ -188,7 +232,7 @@ class RasterMixin:
         return self._render_glyph(glyph, **plot_style)
 
     def hsv_composite(self, dataset: Any, bands: Sequence[int] = (1, 2, 3), *, mask_nodata: bool = True,
-                      **opts) -> Any:
+                      stretch_limits: Optional[Sequence[Tuple[float, float]]] = None, **opts) -> Any:
         """Render three raster bands as an HSV composite (hue/sat/value → RGB → image).
 
         Args:
@@ -196,6 +240,9 @@ class RasterMixin:
             bands: Three 1-based band indices mapped to H, S, V. Defaults to ``(1, 2, 3)``.
             mask_nodata: When ``True`` (default) each band's nodata cells are excluded from the 2-98
                 percentile stretch (and render transparent). Pass ``False`` for the raw pre-mask behaviour.
+            stretch_limits: Optional per-channel ``(low, high)`` bounds for the contrast stretch, one pair
+                per band; ``None`` (default) derives them from this raster alone. See
+                :meth:`rgb_composite` for why an animation freezes them across the stack.
             **opts: Styling kwargs, filtered to ``ArrayGlyph``'s accepted options.
 
         Returns:
@@ -205,7 +252,7 @@ class RasterMixin:
 
         ds = self._reproject(dataset)
         stack = get_stack(ds, bands, mask=mask_nodata)  # (rows, cols, n); nodata -> NaN unless mask_nodata=False
-        rgb = hsv_to_rgb(_stretch_to_unit(stack))                      # (rows, cols, 3) RGB
+        rgb = hsv_to_rgb(_stretch_to_unit(stack, stretch_limits))      # (rows, cols, 3) RGB
         # band-FIRST for cleopatra's RgbBands path (see rgb_composite); it transposes back to band-last.
         band_first = np.moveaxis(rgb, -1, 0)
         plot_style = relocate_flat_style(opts)

--- a/src/digitalearth/sources/extractors.py
+++ b/src/digitalearth/sources/extractors.py
@@ -187,13 +187,27 @@ def _from_feature(fc: Any, metadata: Optional[dict]) -> Source:
         cent = geom.centroid
         xs, ys = cent.x.to_numpy(), cent.y.to_numpy()
 
+    # `pandas.api.types.is_numeric_dtype`, not `np.issubdtype`: the latter only understands numpy dtypes
+    # and *raises* on a pandas extension dtype (`string`, `Int64`, `boolean`) rather than answering False,
+    # so one nullable column anywhere in the frame took the whole render down (#157).
+    from pandas.api.types import is_bool_dtype, is_numeric_dtype
+
+    # `is_numeric_dtype` counts booleans, where the previous `np.issubdtype(..., np.number)` did not
+    # (numpy's bool is not a subtype of `number`). Keep the old meaning: a flag column is not a value
+    # to colour by, and promoting one to the value column would change what existing frames render.
     value_cols = [
         c
         for c in fc.columns
-        if c != geom_name and np.issubdtype(fc[c].dtype, np.number)
+        if c != geom_name and is_numeric_dtype(fc[c]) and not is_bool_dtype(fc[c])
     ]
     column = value_cols[0] if value_cols else None
-    z = _axis(fc[column].to_numpy(), "z") if column is not None else None
+    # A nullable numeric column (`Int64`) is numeric but `.to_numpy()` yields an object array holding
+    # `pd.NA`, which no colour mapper can read — ask for float64 with NaN in its place.
+    z = (
+        _axis(fc[column].to_numpy(dtype="float64", na_value=np.nan), "z")
+        if column is not None
+        else None
+    )
 
     return Source(
         z=z,

--- a/src/digitalearth/three_d/animation.py
+++ b/src/digitalearth/three_d/animation.py
@@ -11,7 +11,7 @@ GIF/MP4 writing uses PyVista's ``open_gif``/``open_movie`` (which need ``imageio
 the ``3d`` extra). No GIS is touched here: animation is pure rendering of already-built meshes; data still comes
 from pyramids upstream.
 """
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Optional, Sequence
 
 #: File suffixes routed to ``open_movie`` (everything else → ``open_gif``).
 _MOVIE_SUFFIXES = (".mp4", ".mov", ".avi", ".m4v")
@@ -51,6 +51,9 @@ class AnimationMixin:
         *,
         n_frames: int = 36,
         framerate: int = 12,
+        factor: float = 3.0,
+        shift: float = 0.0,
+        viewup: Optional[Sequence[float]] = None,
         **orbit_kwargs: Any,
     ) -> str:
         """Sweep the camera around the scene and write the fly-through to a GIF/MP4.
@@ -59,7 +62,16 @@ class AnimationMixin:
             path: Output file. A video suffix (``.mp4``/``.mov``/``.avi``) writes a movie; anything else a GIF.
             n_frames: Number of frames (camera positions) along the orbit.
             framerate: Frames per second of the output.
-            **orbit_kwargs: Forwarded to :meth:`pyvista.Plotter.orbit_on_path` (``factor``, ``viewup`` …).
+            factor: Radius of the orbit as a multiple of the scene's bounding size. Larger pulls the camera
+                back; smaller flies closer in.
+            shift: How far to raise the orbit **above** the mesh's mid-plane, in the scene's own z units.
+                The default ``0.0`` circles level with the middle of the data, which views a terrain almost
+                edge-on and makes the turn hard to read — raising it tilts the camera down onto the surface.
+                It is an absolute offset, so scale it against the data: a useful starting point is a small
+                fraction of the horizontal extent.
+            viewup: The camera's up vector, used for both the orbit path and the camera as it travels. ``None``
+                takes the plotter theme's.
+            **orbit_kwargs: Forwarded to :meth:`pyvista.Plotter.orbit_on_path` (``step``, ``focus`` …).
 
         Returns:
             The ``path`` written.
@@ -82,7 +94,13 @@ class AnimationMixin:
         """
         _open_writer(self.plotter, path, framerate)
         try:
-            orbital_path = self.plotter.generate_orbital_path(n_points=n_frames)
+            # `factor`/`shift`/`viewup` shape the *path*, so they belong to generate_orbital_path — they are
+            # not orbit_on_path arguments, which is why they were unreachable before (#159).
+            orbital_path = self.plotter.generate_orbital_path(
+                factor=factor, n_points=n_frames, viewup=viewup, shift=shift
+            )
+            # Keep the travelling camera's up vector the same as the path's, unless the caller overrode it.
+            orbit_kwargs.setdefault("viewup", viewup)
             self.plotter.orbit_on_path(orbital_path, write_frames=True, **orbit_kwargs)
         finally:
             _finalize_frames(self.plotter)  # always flush/close the writer, even if rendering raised

--- a/src/digitalearth/web/base.py
+++ b/src/digitalearth/web/base.py
@@ -304,6 +304,39 @@ class WebMapBase:
             data = data.to_crs(self.crs)
         return get_source(data, band=band)
 
+    @staticmethod
+    def _json_safe(gdf: Any) -> Any:
+        """Return ``gdf`` with datetime-like columns encoded as ISO-8601 strings.
+
+        MapLibre ingests a GeoDataFrame by serialising it to GeoJSON with ``json.dumps``, and GeoJSON has
+        no date type — so a ``Timestamp`` column raises ``TypeError`` and takes the whole map with it. A
+        timestamp is the norm for the data this tier renders (alerts, detections, observations), so the
+        coercion happens here rather than being left to the caller (#156).
+
+        ISO-8601 is the encoding chosen because it is what GeoJSON consumers expect, it still sorts
+        lexicographically — which is what keeps :meth:`~digitalearth.web.temporal.TemporalMixin.timeslider`
+        ordering its steps correctly — and MapLibre expressions can compare the strings directly. ``NaT``
+        becomes ``None`` (GeoJSON ``null``) rather than the string ``"NaT"``, which would otherwise surface
+        in a popup as though it were a real value.
+
+        Args:
+            gdf: The display-CRS GeoDataFrame about to be handed to ``add_source``.
+
+        Returns:
+            The same object when it holds no datetime column, else a shallow copy with those columns
+            converted. The input is never mutated — it is the caller's frame.
+        """
+        from pandas.api.types import is_datetime64_any_dtype
+
+        stamped = [name for name in gdf.columns if is_datetime64_any_dtype(gdf[name])]
+        if not stamped:
+            return gdf
+        out = gdf.copy()
+        for name in stamped:
+            iso = out[name].dt.strftime("%Y-%m-%dT%H:%M:%S%z")
+            out[name] = iso.where(out[name].notna(), None)
+        return out
+
     def _display_gdf(self, features: Any) -> Any:
         """Reproject a vector input to the display CRS (lon/lat) and return a GeoDataFrame.
 
@@ -322,11 +355,11 @@ class WebMapBase:
         if hasattr(features, "epsg") and hasattr(features, "to_crs"):  # pyramids FeatureCollection (a GeoDataFrame)
             if self._needs_reproject(features):
                 features = features.to_crs(self.crs)
-            return features
+            return self._json_safe(features)
         crs_epsg = getattr(getattr(features, "crs", None), "to_epsg", lambda: None)()
         if crs_epsg is not None and crs_epsg != self.crs:  # a bare GeoDataFrame in another CRS
-            return features.to_crs(self.crs)
-        return features
+            return self._json_safe(features.to_crs(self.crs))
+        return self._json_safe(features)
 
     def add_underlay(self, layer: Any) -> "WebMapBase":
         """Register ``layer`` at the **bottom** of the stack (drawn first) and return ``self``.

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -5,6 +5,8 @@ from matplotlib.animation import FuncAnimation, PillowWriter
 from pyramids.dataset import Dataset, GeoReference
 
 from digitalearth.scene import Map, projections
+from digitalearth.scene.maps.raster import _stretch_to_unit, channel_limits
+from digitalearth.sources import get_stack
 
 
 def _field(offset: float) -> Dataset:
@@ -23,6 +25,36 @@ def _field(offset: float) -> Dataset:
         arr=z.astype("float32"),
         geo_ref=GeoReference(geo=(-180.0, 3.0, 0.0, 90.0, 0.0, -3.0), epsg=4326),
     )
+
+
+def _rgb_field(offset: float, exposure: float = 1.0) -> Dataset:
+    """A small 3-band global field, shifted by ``offset`` and scaled by ``exposure``.
+
+    Args:
+        offset: Constant added to every band (distinguishes stack frames).
+        exposure: Multiplier applied to every band, standing in for a brighter or darker scene.
+
+    Returns:
+        Dataset: a 3-band 60x120 global EPSG:4326 raster.
+    """
+    ny, nx = 60, 120
+    lat = np.linspace(90, -90, ny)[:, None]
+    base = (np.cos(np.deg2rad(lat)) * 30 + offset) * np.ones((ny, nx), "float32")
+    bands = np.stack([base * exposure, base * 0.6 * exposure, base * 0.3 * exposure])
+    return Dataset.from_array(
+        arr=bands.astype("float32"),
+        geo_ref=GeoReference(geo=(-180.0, 3.0, 0.0, 90.0, 0.0, -3.0), epsg=4326),
+    )
+
+
+@pytest.fixture
+def rgb_stack():
+    """A 3-frame stack of small 3-band global fields.
+
+    Returns:
+        list[Dataset]: three distinct 3-band rasters.
+    """
+    return [_rgb_field(o) for o in (0.0, 15.0, 30.0)]
 
 
 @pytest.fixture
@@ -285,3 +317,93 @@ class TestDrawAnimationFrame:
         m = Map(crs=4326)
         m._draw_animation_frame(_field(0.0), "imshow", {}, ocean=False, coastlines=False)
         assert m.ax.get_title() == "", f"title should be empty, got {m.ax.get_title()!r}"
+
+
+class TestAnimateComposites:
+    """Tests for animating RGB/HSV composites (issue #150)."""
+
+    @pytest.mark.parametrize("kind", ["rgb_composite", "hsv_composite"])
+    def test_composite_is_an_accepted_kind(self, rgb_stack, kind):
+        """A composite kind animates instead of being rejected as unknown."""
+        m = Map(crs=4326, figsize=(4, 4))
+        anim = m.animate(rgb_stack, kind=kind, fps=2)
+        assert isinstance(anim, FuncAnimation), f"expected FuncAnimation, got {type(anim)}"
+        assert len(list(anim.new_frame_seq())) == len(rgb_stack), "frame count must match the stack length"
+
+    def test_composite_renders_a_gif(self, rgb_stack, tmp_path):
+        """A composite animation renders every frame to a non-empty GIF."""
+        m = Map(crs=4326, figsize=(4, 4))
+        anim = m.animate(rgb_stack, kind="rgb_composite", fps=2, titles=["a", "b", "c"])
+        out = tmp_path / "rgb.gif"
+        anim.save(str(out), writer=PillowWriter(fps=2))
+        assert out.exists() and out.stat().st_size > 0, "composite GIF should be non-empty"
+        assert m.ax.get_title() == "c", "the last frame's title should remain on the axes"
+
+    def test_colorbar_on_a_composite_is_refused(self, rgb_stack):
+        """A composite has no single value scale, so colorbar=True is rejected rather than drawn."""
+        m = Map(crs=4326, figsize=(4, 4))
+        with pytest.raises(ValueError, match="colorbar=True is not meaningful"):
+            m.animate(rgb_stack, kind="rgb_composite", colorbar=True)
+
+    def test_stretch_is_frozen_across_the_stack(self):
+        """One stretch spans the whole stack, so a real exposure change survives instead of being erased."""
+        dark, bright = _rgb_field(0.0, exposure=0.5), _rgb_field(0.0, exposure=1.0)
+        opts: dict = {}
+        Map(crs=4326)._resolve_composite_stretch([dark, bright], opts)
+        limits = opts["stretch_limits"]
+        rendered = [_stretch_to_unit(get_stack(ds, (1, 2, 3)), limits).mean() for ds in (dark, bright)]
+        assert rendered[1] - rendered[0] > 0.05, (
+            f"the frozen stretch flattened a 2x exposure difference to {rendered}; frames would not differ"
+        )
+        per_frame = [_stretch_to_unit(get_stack(ds, (1, 2, 3))).mean() for ds in (dark, bright)]
+        assert abs(per_frame[1] - per_frame[0]) < 0.01, (
+            "per-frame stretch is expected to erase the difference — that is the flicker this guards against"
+        )
+
+    def test_explicit_stretch_limits_are_kept(self, rgb_stack):
+        """Caller-supplied stretch_limits are honoured, not overwritten by the stack scan."""
+        given = [(0.0, 10.0), (0.0, 20.0), (0.0, 30.0)]
+        opts = {"stretch_limits": given}
+        Map(crs=4326)._resolve_composite_stretch(rgb_stack, opts)
+        assert opts["stretch_limits"] is given, "an explicit stretch must not be recomputed"
+
+    def test_composite_scan_is_capped(self, mocker):
+        """The stack scan samples at most _CLIM_SCAN_CAP frames, however long the stack."""
+        from digitalearth.scene.maps import animation as anim_mod
+
+        spy = mocker.spy(anim_mod, "get_stack")
+        big = [_rgb_field(float(o)) for o in range(anim_mod._CLIM_SCAN_CAP * 3)]
+        opts: dict = {}
+        Map(crs=4326)._resolve_composite_stretch(big, opts)
+        assert spy.call_count <= anim_mod._CLIM_SCAN_CAP, (
+            f"scanned {spy.call_count} frames, cap is {anim_mod._CLIM_SCAN_CAP}"
+        )
+        assert len(opts["stretch_limits"]) == 3, "one bound pair per band"
+
+
+class TestChannelLimits:
+    """Tests for the stretch-bounds helpers the composite animation path depends on."""
+
+    def test_limits_are_reused_verbatim(self):
+        """Passing limits bypasses the per-array percentile derivation."""
+        stack = np.dstack([np.arange(100.0).reshape(10, 10) for _ in range(3)])
+        out = _stretch_to_unit(stack, [(0.0, 99.0)] * 3)
+        assert out.min() == pytest.approx(0.0) and out.max() == pytest.approx(1.0)
+
+    def test_channel_limits_one_pair_per_band(self):
+        """channel_limits returns a (low, high) pair for each channel, low < high."""
+        stack = np.dstack([np.arange(100.0).reshape(10, 10) * s for s in (1.0, 2.0, 3.0)])
+        limits = channel_limits(stack)
+        assert len(limits) == 3
+        assert all(high > low for low, high in limits)
+
+    def test_flat_channel_does_not_divide_by_zero(self):
+        """A constant channel gets a nudged upper bound so the stretch stays finite."""
+        stack = np.dstack([np.full((4, 4), 7.0), np.zeros((4, 4)), np.ones((4, 4))])
+        assert np.isfinite(_stretch_to_unit(stack, channel_limits(stack))).all()
+
+    def test_wrong_number_of_limits_is_rejected(self):
+        """Limits that do not match the channel count raise rather than silently mis-stretching."""
+        stack = np.dstack([np.zeros((4, 4))] * 3)
+        with pytest.raises(ValueError, match="channel bounds"):
+            _stretch_to_unit(stack, [(0.0, 1.0)])

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -407,3 +407,45 @@ class TestChannelLimits:
         stack = np.dstack([np.zeros((4, 4))] * 3)
         with pytest.raises(ValueError, match="channel bounds"):
             _stretch_to_unit(stack, [(0.0, 1.0)])
+
+
+class TestAnimateDatasetCollection:
+    """Tests for accepting a DatasetCollection as the stack (issue #154)."""
+
+    @pytest.fixture
+    def cube(self, tmp_path, rgb_stack):
+        """The rgb_stack written to disk and reloaded as a DatasetCollection.
+
+        Returns:
+            DatasetCollection: a 3-member datacube.
+        """
+        from pyramids.dataset.collection import DatasetCollection
+
+        paths = []
+        for i, ds in enumerate(rgb_stack):
+            out = tmp_path / f"frame_{i}.tif"
+            ds.to_file(str(out))
+            paths.append(str(out))
+        return DatasetCollection.from_files(paths)
+
+    def test_collection_iterates_to_arrays_not_datasets(self, cube):
+        """The premise: iterating a DatasetCollection yields arrays, which is why animate must unwrap it."""
+        assert not hasattr(list(cube)[0], "read_array"), (
+            "if a collection now iterates to Datasets, the unwrap in animate is redundant"
+        )
+
+    def test_animate_accepts_a_collection(self, cube):
+        """A DatasetCollection animates directly, as the docstring promises."""
+        anim = Map(crs=4326, figsize=(4, 4)).animate(cube, kind="rgb_composite", fps=2)
+        assert len(list(anim.new_frame_seq())) == len(cube.datasets), "one frame per member"
+
+    def test_collection_matches_an_explicit_list(self, cube, tmp_path):
+        """Passing the collection and passing its .datasets produce the same clip."""
+        outputs = []
+        for stack in (cube, cube.datasets):
+            m = Map(crs=4326, figsize=(4, 4))
+            anim = m.animate(stack, kind="rgb_composite", fps=2)
+            out = tmp_path / f"{'collection' if stack is cube else 'list'}.gif"
+            anim.save(str(out), writer=PillowWriter(fps=2))
+            outputs.append(out.read_bytes())
+        assert outputs[0] == outputs[1], "a collection must animate identically to its member list"

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -449,3 +449,33 @@ class TestAnimateDatasetCollection:
             anim.save(str(out), writer=PillowWriter(fps=2))
             outputs.append(out.read_bytes())
         assert outputs[0] == outputs[1], "a collection must animate identically to its member list"
+
+
+class TestClimFollowsTheBand:
+    """Tests that the shared colour scale is read off the band being animated (issue #155)."""
+
+    @staticmethod
+    def _two_band(k):
+        """A 2-band frame whose bands sit in very different ranges."""
+        b1 = np.full((40, 50), 1.0 + k, dtype="float32")
+        b2 = np.full((40, 50), 500.0 + 100 * k, dtype="float32")
+        return Dataset.from_array(
+            arr=np.stack([b1, b2]),
+            geo_ref=GeoReference(geo=(0.0, 1.0, 0.0, 40.0, 0.0, -1.0), epsg=4326),
+        )
+
+    def test_clim_matches_the_animated_band(self):
+        """band=2 scales from band 2's range, not band 1's."""
+        frames = [self._two_band(k) for k in range(3)]
+        opts = {"band": 2}
+        Map(crs=4326)._resolve_animation_clim(frames, opts)
+        assert (opts["vmin"], opts["vmax"]) == pytest.approx((500.0, 700.0)), (
+            f"band 2 spans 500-700 but the scale resolved to {opts['vmin']}-{opts['vmax']}"
+        )
+
+    def test_band_one_is_still_the_default(self):
+        """With no band given, the scan still reads band 1."""
+        frames = [self._two_band(k) for k in range(3)]
+        opts = {}
+        Map(crs=4326)._resolve_animation_clim(frames, opts)
+        assert (opts["vmin"], opts["vmax"]) == pytest.approx((1.0, 3.0))

--- a/tests/test_animation3d.py
+++ b/tests/test_animation3d.py
@@ -119,3 +119,49 @@ def test_animate_finalizes_writer_even_when_update_raises(tmp_path):
     # finally-block ran: the writer was flushed/closed (no lingering open mwriter)
     assert getattr(scene.plotter, "mwriter", None) is None or scene.plotter.mwriter.closed
     scene.close()
+
+
+class TestOrbitPathShape:
+    """orbit() can shape its own path, not just its length (issue #159)."""
+
+    @staticmethod
+    def _scene():
+        """A tiny off-screen terrain scene."""
+        import numpy as np
+
+        from digitalearth.sources import get_source
+        from digitalearth.three_d import Scene3D
+
+        dem = np.add.outer(np.linspace(0, 1, 8), np.linspace(0, 1, 8))
+        scene = Scene3D(off_screen=True)
+        scene.terrain(get_source(dem), z_exaggeration=3.0)
+        return scene
+
+    def test_shift_and_factor_reach_the_path_generator(self, mocker, tmp_path):
+        """shift/factor/viewup go to generate_orbital_path, which is what shapes the orbit."""
+        scene = self._scene()
+        spy = mocker.spy(scene.plotter, "generate_orbital_path")
+        scene.orbit(str(tmp_path / "o.gif"), n_frames=4, factor=0.7, shift=2.4)
+        scene.close()
+        assert spy.call_args.kwargs["factor"] == 0.7
+        assert spy.call_args.kwargs["shift"] == 2.4
+        assert spy.call_args.kwargs["n_points"] == 4
+
+    def test_viewup_reaches_both_the_path_and_the_camera(self, mocker, tmp_path):
+        """The travelling camera shares the path's up vector by default."""
+        scene = self._scene()
+        path_spy = mocker.spy(scene.plotter, "generate_orbital_path")
+        travel_spy = mocker.spy(scene.plotter, "orbit_on_path")
+        scene.orbit(str(tmp_path / "o.gif"), n_frames=4, viewup=[0, 0, 1])
+        scene.close()
+        assert path_spy.call_args.kwargs["viewup"] == [0, 0, 1]
+        assert travel_spy.call_args.kwargs["viewup"] == [0, 0, 1]
+
+    def test_defaults_match_pyvista(self, mocker, tmp_path):
+        """Unset, the arguments keep pyvista's own defaults, so existing clips are unchanged."""
+        scene = self._scene()
+        spy = mocker.spy(scene.plotter, "generate_orbital_path")
+        scene.orbit(str(tmp_path / "o.gif"), n_frames=4)
+        scene.close()
+        assert spy.call_args.kwargs["factor"] == 3.0
+        assert spy.call_args.kwargs["shift"] == 0.0

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -214,3 +214,47 @@ def test_raster_source_nodata_is_exact_not_tolerant():
     assert np.isnan(z[0, 1]), "exact nodata cell should be masked"
     assert not np.isnan(z[1, 0]), "a value near (but != ) nodata must be kept under exact-compare"
     assert z[0, 0] == 1.0 and z[1, 1] == 4.0, f"real values changed: {z}"
+
+
+class TestExtensionDtypes:
+    """A pandas extension dtype must not break the value-column scan (issue #157)."""
+
+    @staticmethod
+    def _frame(**columns):
+        """A two-point GeoDataFrame carrying the given columns."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        return gpd.GeoDataFrame(columns, geometry=[Point(0, 0), Point(1, 1)], crs=4326)
+
+    def test_nullable_string_is_skipped_not_raised(self):
+        """A `string` column is ignored, and the numeric column is still found."""
+        import pandas as pd
+        from pyramids.feature import FeatureCollection
+
+        frame = self._frame(name=pd.array(["a", "b"], dtype="string"), score=[1.0, 2.0])
+        src = get_source(FeatureCollection(frame))
+        assert src.metadata("variable") == "score"
+        assert src.z.values.tolist() == [1.0, 2.0]
+
+    def test_nullable_integer_is_read_as_float_with_nan(self):
+        """An `Int64` column is numeric, and its pd.NA arrives as NaN rather than an object."""
+        import numpy as np
+        import pandas as pd
+        from pyramids.feature import FeatureCollection
+
+        frame = self._frame(count=pd.array([3, None], dtype="Int64"))
+        src = get_source(FeatureCollection(frame))
+        assert src.z.values.dtype == np.dtype("float64")
+        assert src.z.values[0] == 3.0
+        assert np.isnan(src.z.values[1])
+
+    def test_a_frame_of_only_extension_columns_has_no_value(self):
+        """No numeric column at all still resolves, with z unset rather than an error."""
+        import pandas as pd
+        from pyramids.feature import FeatureCollection
+
+        frame = self._frame(name=pd.array(["a", "b"], dtype="string"),
+                            flag=pd.array([True, False], dtype="boolean"))
+        src = get_source(FeatureCollection(frame))
+        assert src.z is None

--- a/tests/test_web_base.py
+++ b/tests/test_web_base.py
@@ -323,3 +323,56 @@ def test_reimport_is_stable():
     """The package re-imports cleanly (no import-time engine side effects)."""
     mod = importlib.reload(importlib.import_module("digitalearth.web"))
     assert hasattr(mod, "WebMap")
+
+
+class TestJsonSafeDatetimes:
+    """Datetime columns are ISO-encoded before the frame reaches GeoJSON (issue #156)."""
+
+    @staticmethod
+    def _frame():
+        """A point frame with a tz-naive datetime column and a NaT."""
+        import geopandas as gpd
+        import pandas as pd
+        from shapely.geometry import Point
+
+        return gpd.GeoDataFrame(
+            {
+                "name": ["a", "b", "c"],
+                "score": [1.0, 2.0, 3.0],
+                "from_date": pd.to_datetime(["2026-01-01 06:00", "2026-02-01 18:30", None]),
+            },
+            geometry=[Point(0, 0), Point(1, 1), Point(2, 2)],
+            crs=4326,
+        )
+
+    def test_timestamps_become_iso_strings(self):
+        """A Timestamp column is replaced by ISO-8601 text, which json can serialise."""
+        import json
+
+        out = WebMap()._json_safe(self._frame())
+        assert out["from_date"].iloc[0].startswith("2026-01-01T06:00:00")
+        json.dumps(out.drop(columns="geometry").to_dict(orient="records"))  # must not raise
+
+    def test_nat_becomes_null_not_the_string(self):
+        """A missing timestamp serialises as null rather than the text 'NaT'."""
+        out = WebMap()._json_safe(self._frame())
+        assert out["from_date"].iloc[2] is None
+
+    def test_iso_text_still_sorts_chronologically(self):
+        """The encoding keeps timeslider's ordering valid — lexicographic == chronological."""
+        out = WebMap()._json_safe(self._frame())
+        stamps = [s for s in out["from_date"] if s is not None]
+        assert stamps == sorted(stamps)
+
+    def test_frames_without_datetimes_are_passed_through(self):
+        """No datetime column means no copy — the caller's frame is returned as-is."""
+        frame = self._frame().drop(columns="from_date")
+        assert WebMap()._json_safe(frame) is frame
+
+    def test_the_callers_frame_is_not_mutated(self):
+        """Coercion happens on a copy; the frame the caller still holds keeps its dtype."""
+        import pandas as pd
+
+        frame = self._frame()
+        WebMap()._json_safe(frame)
+        assert pd.api.types.is_datetime64_any_dtype(frame["from_date"])


### PR DESCRIPTION
# Description

`Map` could render a true-colour composite as a still (`rgb_composite` / `hsv_composite`) but not as an
animation. `_ANIMATION_KINDS` listed only the scalar field renderers, so `animate(kind="rgb_composite")`
was rejected before a single frame was drawn:

```
ValueError: unknown animation kind 'rgb_composite'; choose one of
('imshow', 'contourf', 'contour', 'pcolormesh', 'block')
```

That left no way to build a true-colour time-lapse through the matplotlib tier — the only tier that writes
an mp4/GIF from one render — even though a Landsat/Sentinel-2 R/G/B stack over time is the most common
shape of satellite animation.

Three things changed:

1. **`rgb_composite` / `hsv_composite` are accepted animation kinds** (`_COMPOSITE_KINDS`, folded into
   `_ANIMATION_KINDS`).
2. **The contrast stretch is frozen across the stack.** `_stretch_to_unit` derives its 2-98 percentiles per
   call, so driven per frame every frame got its own black and white point and an unchanged scene still
   pulsed in brightness — the artefact a viewer reads as the data changing. The stack is now scanned once
   (capped at `_CLIM_SCAN_CAP` sampled frames, as the clim scan already is) and the bounds pinned into a new
   `stretch_limits` argument that both composites accept; an explicit value from the caller is honoured
   untouched.
3. **The scalar priming no longer runs for a composite.** A shared `vmin`/`vmax` means nothing to a renderer
   that paints colour from three bands, and there is no single mappable a colorbar could describe, so
   `colorbar=True` is refused with a message pointing at `kind="imshow"` rather than drawing a misleading
   one.

`channel_limits` is split out of `_stretch_to_unit` as the reusable "bounds of this stack" helper.

**Second fix, same method (#154).** `animate` documents a `DatasetCollection` datacube as valid input, but
a collection iterates to numpy arrays rather than to its members, so `list(stack)` handed bare arrays to
the renderers and the first frame died on `.read_array`. It now unwraps `.datasets` when the stack exposes
it. That is the container a raster time stack actually arrives in — `DatasetCollection.from_files(...)`
returns one, and the pyramids animation path takes one directly — so it is the first thing a caller passes.

**Third fix, same method (#155).** `_stack_clim` hardcoded `band=1` while `band` was forwarded to the
renderer for the actual draw, so `animate(band=N)` for any N but 1 scaled the clip against the wrong range
— normally saturating every frame, and mislabelling the `colorbar=True` bar with band 1's bounds. The scan
now reads `opts.get("band", 1)`.

All three are the same failure shape: `animate` deciding a colour treatment that does not match what it
then draws.

No new dependencies.

- Fixes #150 — `Map.animate` cannot animate RGB/HSV composites
- Fixes #154 — `Map.animate` documents `DatasetCollection` but breaks on one
- Fixes #155 — `Map.animate(band=N)` derives the shared colour scale from band 1

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Full suite on Windows, Python 3.14: **1258 passed, 2 failed, 2 skipped**. Both failures reproduce
identically on untouched `main` and are unrelated to this change:

- `test_interactive_temporal.py::TestTimecube::test_datetime_labels_drive_the_slider` — a
  `np.datetime64` vs `datetime.datetime` comparison drift from newer pandas/holoviews.
- `test_scene3d.py::test_save_dispatches_png_vs_html` — `ImportError: The "trame" plotter component is not
  registered` (no `trame-pyvista` in the test env).

`tests/test_animate.py` + `tests/test_composite.py`: **48 passed**, including 16 new tests.

- [x] Both composite kinds animate and return a `FuncAnimation` with the right frame count
- [x] A composite animation renders every frame to a non-empty GIF, keeping per-frame titles
- [x] `colorbar=True` on a composite raises rather than drawing a meaningless bar
- [x] **The frozen stretch is verified against the flicker it exists to prevent**: two frames of identical
      scene content at 0.5x and 1.0x exposure stay visibly different under the stack-wide stretch
      (`0.291` vs `0.543` mean), and are flattened to the same value (`0.537` vs `0.537`) under the
      per-frame stretch — the regression this guards
- [x] An explicit `stretch_limits` is not overwritten by the stack scan
- [x] The stack scan is capped at `_CLIM_SCAN_CAP` frames
- [x] `channel_limits` bounds, flat-channel division guard, and the mismatched-length `ValueError`
- [x] A `DatasetCollection` animates directly, and produces a **byte-identical** GIF to passing its
      `.datasets` list — plus a guard test asserting the premise (a collection iterates to arrays), so the
      unwrap is removed rather than left dangling if pyramids ever changes that
- [x] `animate(band=2)` resolves the scale from band 2's range (500-700) and not band 1's (1-3), with the
      no-band default still reading band 1
- [x] CI gates: `ruff check --select F821 src tests docs` passes; `pytest --doctest-modules` on the changed
      modules passes (12). The three changed files are also clean under `I001`; the 23 `I001` findings
      elsewhere in `src`/`tests` are identical on `main` (the pre-existing drift `tests.yml` documents).

# Checklist:

- [ ] updated version number in setup.py/pyproject.toml
- [ ] updated environment.yml and the lock file
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Version/changelog boxes left unticked — no dependency change, and the release tooling owns the version bump.
